### PR TITLE
Add GR00T N1.5 VLA package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For detailed build and run instructions, refer to the included documentation.
 | Category        | Software                                                                                                    |
 |-----------------|--------------------------------------------------------------------------------------------------------------------|
 | LLM                     | [`ollama`](packages/llm/ollama), [`llamacpp`](packages/llm/llamacpp)   |
-| VLM / VLAM              | [`OpenVLA`](packages/robotics/openvla), [`SmolVLA`](packages/robotics/smolvla) |
+| VLM / VLA              | [`OpenVLA`](packages/robotics/openvla), [`SmolVLA`](packages/robotics/smolvla), [`GR00T-N1.5`](packages/robotics/gr00t) |
 | Graphics                     | [`O3DE`](packages/graphics/o3de) |
 | Robotics                | [`ROS 2`](packages/ros/ros), [`Gazebo`](packages/ros/gazebo), [`LeRobot`](packages/robotics/lerobot). [`ACT`](packages/robotics/act)    |
 | Simulation                |  [`Genesis`](packages/robotics/genesis)  |

--- a/packages/robotics/gr00t/Dockerfile
+++ b/packages/robotics/gr00t/Dockerfile
@@ -40,6 +40,7 @@ RUN git clone --recursive https://github.com/ROCm/flash-attention && \
     python setup.py install
 
 # Build torchcodec from source
+ENV PYTORCH_ROCM_ARCH="gfx1151"
 RUN git clone https://github.com/pytorch/torchcodec.git && \
     cd /ryzers/torchcodec && \
     sed -i 's/-Werror//g' src/torchcodec/_core/CMakeLists.txt && \

--- a/packages/robotics/gr00t/Dockerfile
+++ b/packages/robotics/gr00t/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get install -y \
     rocm-dev \
     hipcc \
     cmake \
+    python3-pybind11 \
+    pybind11-dev \
     ffmpeg \
     libavdevice-dev \
     libavfilter-dev \

--- a/packages/robotics/gr00t/Dockerfile
+++ b/packages/robotics/gr00t/Dockerfile
@@ -7,7 +7,21 @@ FROM ${BASE_IMAGE}
 WORKDIR /ryzers
 
 # Install deps
-RUN apt-get update && apt-get install -y git wget rocm-dev hipcc
+RUN apt-get install -y \
+    git \
+    wget \
+    rocm-dev \
+    hipcc \
+    cmake \
+    ffmpeg \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavcodec-dev \
+    libavutil-dev \
+    libswresample-dev \
+    libswscale-dev \
+    pkg-config
 
 RUN pip install zmq diffusers decord
 
@@ -22,6 +36,12 @@ RUN git clone --recursive https://github.com/ROCm/flash-attention && \
     cd flash-attention && \
     git checkout main_perf && \
     python setup.py install
+
+# Build torchcodec from source
+RUN git clone https://github.com/pytorch/torchcodec.git && \
+    cd /ryzers/torchcodec && \
+    sed -i 's/-Werror//g' src/torchcodec/_core/CMakeLists.txt && \
+    pip install -e . --no-build-isolation
 
 RUN git clone https://github.com/NVIDIA/Isaac-GR00T && \
     cd Isaac-GR00T && \

--- a/packages/robotics/gr00t/Dockerfile
+++ b/packages/robotics/gr00t/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+WORKDIR /ryzers
+
+# Install deps
+RUN apt-get update && apt-get install -y git wget rocm-dev hipcc
+
+RUN pip install zmq diffusers decord
+
+# Build pytorch3d since there's no wheel for python3.12
+ENV FORCE_CUDA=1
+RUN pip install --no-build-isolation "git+https://github.com/facebookresearch/pytorch3d.git"
+
+# Install flash attention
+ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" 
+ENV BUILD_TYPE="rocm"
+RUN git clone --recursive git@github.com:ROCm/flash-attention.git && \
+    cd flash-attention && \
+    git checkout main_perf && \
+    python setup.py install
+
+RUN git clone https://github.com/NVIDIA/Isaac-GR00T && \
+    cd Isaac-GR00T && \
+    pip install -e .
+
+COPY test.py /ryzers/test.py
+COPY test.sh /ryzers/test.sh
+RUN chmod +x /ryzers/test.sh
+
+CMD ["/bin/bash", "-c", "/ryzers/test.sh"]

--- a/packages/robotics/gr00t/Dockerfile
+++ b/packages/robotics/gr00t/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-build-isolation "git+https://github.com/facebookresearch/py
 # Install flash attention
 ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" 
 ENV BUILD_TYPE="rocm"
-RUN git clone --recursive git@github.com:ROCm/flash-attention.git && \
+RUN git clone --recursive https://github.com/ROCm/flash-attention && \
     cd flash-attention && \
     git checkout main_perf && \
     python setup.py install

--- a/packages/robotics/gr00t/README.md
+++ b/packages/robotics/gr00t/README.md
@@ -1,0 +1,12 @@
+### Isaac GR00T
+
+This directory contains the docker configuration files to run [GR00T-N1.5](https://github.com/NVIDIA/Isaac-GR00T).
+
+### Build and run the Docker Image
+
+```sh
+ryzers build gr00t
+ryzers run
+```
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/packages/robotics/gr00t/README.md
+++ b/packages/robotics/gr00t/README.md
@@ -9,4 +9,6 @@ ryzers build gr00t
 ryzers run
 ```
 
+**NOTE**: the image can take as long as 30min to build because some dependencies like pytorch3d need to be built from source.
+
 Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/packages/robotics/gr00t/config.yaml
+++ b/packages/robotics/gr00t/config.yaml
@@ -1,0 +1,6 @@
+# Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+environment_variables:
+- "HSA_OVERRIDE_GFX_VERSION=11.0.0"  # Required for HIP to write kernels
+

--- a/packages/robotics/gr00t/test.py
+++ b/packages/robotics/gr00t/test.py
@@ -35,4 +35,4 @@ policy = Gr00tPolicy(
 
 # Run inference
 action_chunk = policy.get_action(dataset[0])
-
+print(action_chunk)

--- a/packages/robotics/gr00t/test.py
+++ b/packages/robotics/gr00t/test.py
@@ -1,0 +1,38 @@
+# Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from gr00t.data.dataset import LeRobotSingleDataset
+from gr00t.data.embodiment_tags import EmbodimentTag
+from gr00t.data.dataset import ModalityConfig
+from gr00t.experiment.data_config import DATA_CONFIG_MAP
+
+# get the data config
+data_config = DATA_CONFIG_MAP["fourier_gr1_arms_only"]
+
+# get the modality configs and transforms
+modality_config = data_config.modality_config()
+transforms = data_config.transform()
+
+# This is a LeRobotSingleDataset object that loads the data from the given dataset path.
+dataset = LeRobotSingleDataset(
+    dataset_path="demo_data/robot_sim.PickNPlace",
+    modality_configs=modality_config,
+    transforms=None,  # we can choose to not apply any transforms
+    embodiment_tag=EmbodimentTag.GR1, # the embodiment to use
+)
+
+from gr00t.model.policy import Gr00tPolicy
+from gr00t.data.embodiment_tags import EmbodimentTag
+
+# Load pre-trained model
+policy = Gr00tPolicy(
+    model_path="nvidia/GR00T-N1.5-3B",
+    modality_config=modality_config,
+    modality_transform=transforms,
+    embodiment_tag=EmbodimentTag.GR1,
+    device="cuda"
+)
+
+# Run inference
+action_chunk = policy.get_action(dataset[0])
+

--- a/packages/robotics/gr00t/test.sh
+++ b/packages/robotics/gr00t/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+python3 test.py

--- a/packages/robotics/gr00t/test.sh
+++ b/packages/robotics/gr00t/test.sh
@@ -3,4 +3,5 @@
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-python3 test.py
+cd /ryzers/Isaac-GR00T/
+python /ryzers/test.py


### PR DESCRIPTION
This package requires pytorch3d and torchcodec as deps, but they're not available as python3.12 wheels for ROCm - that means they are built from source which takes a while. This ryzer build took ~30min on the machine I was testing this on.