### PR TITLE
Gemma3-4B package with test and demo scripts on llamacpp backend

### DIFF
--- a/packages/vlm/gemma3/Dockerfile
+++ b/packages/vlm/gemma3/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+WORKDIR /ryzers
+
+# Download test image
+RUN mkdir -p /ryzers/data/ && \
+    wget https://github.com/AMDResearch/Riallto/blob/main/notebooks/images/jpg/toucan.jpg?raw=true -O /ryzers/data/toucan.jpg
+
+# Copy test script
+COPY test.sh /ryzers/test_gemma3.sh
+COPY demo.sh /ryzers/demo_gemma3.sh
+RUN chmod +x /ryzers/test_gemma3.sh /ryzers/demo_gemma3.sh
+
+CMD /ryzers/test_gemma3.sh

--- a/packages/vlm/gemma3/README.md
+++ b/packages/vlm/gemma3/README.md
@@ -1,0 +1,27 @@
+### Gemma3 (4B)
+
+This directory contains the docker configuration files to run Gemma3-4B on RyzenAI platforms. Gemma3-4B is the smallest open-weights model released under the Gemma3 suite that offers multimodal support.
+
+### Build and run the Docker Image
+
+To build and run a Docker container with Gemma3-4B-Instruct using a llamacpp backend, run:
+
+```sh
+ryzers build llamacpp gemma3
+ryzers run
+```
+
+### Demo
+
+Additionally, there is a demo.sh included that when run on the host machine, will serve up a webpage that allows a user to interact with Gemma3-4B VLM.  A webcam is required. Credit to https://github.com/ngxson/smolvlm-realtime-webcam.
+
+```sh
+git clone https://github.com/ngxson/smolvlm-realtime-webcam <PATH TO REPO>
+
+ryzers build llamacpp gemma3
+ryzers run /ryzers/demo_gemma3.sh
+```
+
+In a browser, open file://\<PATH TO REPO\>/index.html
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/packages/vlm/gemma3/config.yaml
+++ b/packages/vlm/gemma3/config.yaml
@@ -1,0 +1,2 @@
+# Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT

--- a/packages/vlm/gemma3/test.sh
+++ b/packages/vlm/gemma3/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Fixed paths
+export PATH=/ryzers/llamacpp/build/bin/:$PATH
+MODEL="ggml-org/gemma-3-4b-it-GGUF"
+
+# Fixed prompt
+IMAGE="/ryzers/data/toucan.jpg"
+PROMPT="Describe what you see in the image in detail."
+
+# Run
+llama-mtmd-cli -hf $MODEL --image $IMAGE -p "$PROMPT"


### PR DESCRIPTION
Gemma3-4B Instruct model Ryzers package written up similar in style to SmolVLM package. Verified to work on STX-H node. I do not have access to a physical STX-H node, so I cannot test the webcam demo functionality. However, I ran a `curl` script to verify that the demo _should_ work as expected. `curl` script used:

```sh
#!/bin/bash

# Download an image
wget https://github.com/AMDResearch/Riallto/blob/main/notebooks/images/jpg/toucan.jpg\?raw\=true -O ./toucan.jpg

# Convert image to base64 data URL
IMAGE_B64="data:image/jpeg;base64,$(base64 -i ./toucan.jpg)"

# Create temporary JSON file
TEMP_JSON=$(mktemp)
cat > "$TEMP_JSON" << EOF
{
  "max_tokens": 300,
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "What do you see?"
        },
        {
          "type": "image_url",
          "image_url": {
            "url": "$IMAGE_B64"
          }
        }
      ]
    }
  ]
}
EOF

# Send the request
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d @"$TEMP_JSON"

# Clean up
rm "$TEMP_JSON"
rm ./toucan.jpg
```