### PR TITLE
SmolVLA - patch fix for HF hub config changes

### DIFF
--- a/packages/robotics/smolvla/test.py
+++ b/packages/robotics/smolvla/test.py
@@ -11,7 +11,8 @@ from lerobot.common.policies.smolvla.configuration_smolvla import SmolVLAConfig
 from transformers import AutoProcessor
 
 # Load model (replace with your checkpoint if needed)
-policy = SmolVLAPolicy.from_pretrained("lerobot/smolvla_base").to("cuda")
+# Note: locking to hub revision before pipeline update
+policy = SmolVLAPolicy.from_pretrained("lerobot/smolvla_base", revision="3326b10").to("cuda")
 policy.eval()
 
 # patch: The loaded policy is missing the language_tokenizer attribute.


### PR DESCRIPTION
The HF hub HEAD got updated and added a bunch of new fields to the model config to be compatible with their new processor abstraction. This is API breaking for current SmolVLA model class - I don't actually know how they run it on main, but seeing same issue there.

Quick fix for this is locking down the HF hub commit to before the processor update: https://huggingface.co/lerobot/smolvla_base/commits/main