### PR TITLE
jupyter-book CI fix

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U jupyter-book sphinxcontrib.mermaid
+          pip install -U "jupyter-book<2" sphinxcontrib.mermaid
 
       - name: Build the book
         run: jupyter-book build ./docs --all


### PR DESCRIPTION
A couple days ago jupyter-book had their v2.0 release which is now built on MyST and is incompatible with sphinx. Since in our CI we always reinstall latest it broke our pipeline.

This PR locks down jupyter-book version as [recommended](https://github.com/jupyter-book/jupyter-book/compare/v2.0.2...main#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R46) in their docs to keep using v1.0.