### PR TITLE
gr00t n1.5 commit hash added

### DIFF
--- a/packages/vla/gr00t/Dockerfile
+++ b/packages/vla/gr00t/Dockerfile
@@ -48,6 +48,7 @@ RUN git clone https://github.com/pytorch/torchcodec.git && \
 
 RUN git clone https://github.com/NVIDIA/Isaac-GR00T && \
     cd Isaac-GR00T && \
+    git checkout 4af2b62 && \
     pip install -e .
 
 COPY test.py /ryzers/test.py


### PR DESCRIPTION
hotfix as gr00t repository is now n1.6 and breaks backwards compatibility with n1.5
https://github.com/NVIDIA/Isaac-GR00T/pull/456