### PR TITLE
Added --init_image flag to ryzers build command

### DIFF
--- a/ryzers/entrypoint.py
+++ b/ryzers/entrypoint.py
@@ -7,7 +7,7 @@ import argparse
 from .ryzer import RyzerManager
 from .runner import DockerRunner
 
-def build(base_path, name, packages, base_image):
+def build(base_path, name, packages, init_image):
     """
     Builds the Docker images using the specified packages path and selected packages.
 
@@ -15,9 +15,9 @@ def build(base_path, name, packages, base_image):
         base_path (str): The base directory to scan for Dockerfiles.
         name (str): The name of the Docker image to build.
         packages (list): List of package names to manage.
-        base_image (str, optional): The initial base image to start with.
+        init_image (str, optional): The initial base image to start with.
     """
-    mgr = RyzerManager(base_path, name, packages, base_image)
+    mgr = RyzerManager(base_path, name, packages, init_image)
     mgr.build()
 
 def run(name, docker_cmd):
@@ -49,7 +49,7 @@ def main():
     build_parser.add_argument("--base_path", default=default_base_path, help=f"Base path for the project (default: CWD)")
     build_parser.add_argument("--name", default="ryzerdocker", help="Name of the docker image to build")
     build_parser.add_argument("dockerfiles", nargs="*", help="List of Dockerfiles to combine for the build (optional)")
-    build_parser.add_argument("--base_image", default=None, help=f"Initial base image to start with (default: None)")
+    build_parser.add_argument("--init_image", default=None, help=f"Initial base image to start with (default: None)")
 
     # 'run' command
     run_parser = subparsers.add_parser("run", help="Run the project")
@@ -60,7 +60,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == "build":
-        build(args.base_path, args.name, args.dockerfiles, args.base_image)
+        build(args.base_path, args.name, args.dockerfiles, args.init_image)
     elif args.command == "run":
         run(args.name, args.docker_cmd)
     else:

--- a/ryzers/ryzer.py
+++ b/ryzers/ryzer.py
@@ -16,11 +16,11 @@ class RyzerManager:
         docker_builder (DockerBuilder): Builds Docker images from Dockerfiles.
         docker_runner (DockerRunner): Runs Docker containers.
         container_name (str): The name of the container.
-        base_image (str): The initial base image to start with.
+        cli_init_image (str): The initial base image to start with, optionally supplied at the CLI.
         packages (List[str]): List of package names to combine.
     """
 
-    def __init__(self, base_path: str, container_name: str, packages: List[str], base_image: Optional[str]=None):
+    def __init__(self, base_path: str, container_name: str, packages: List[str], cli_init_image: Optional[str]=None):
         """
         Initializes the RyzerManager with the base path, container name, packages, and base image.
 
@@ -28,7 +28,8 @@ class RyzerManager:
             base_path (str): The base directory to scan for Dockerfiles.
             container_name (str): The name of the container.
             packages (List[str]): List of package names to manage.
-            base_image (str, optional): The initial base image to start with. Defaults to RYZERS_DEFAULT_INIT_IMAGE in __init__.py.
+            cli_init_image (str, optional): The initial base image to start with, optionally supplied
+            at the CLI, otherwise defaults to RYZERS_DEFAULT_INIT_IMAGE in __init__.py.
         """
         self.packages = ["ryzer_env"] + packages
         self.docker_manager = DockerPackageManager(base_path, self.packages)
@@ -36,7 +37,7 @@ class RyzerManager:
         self.docker_runner = DockerRunner(container_name)   
 
         self.container_name = container_name
-        self.base_image = base_image
+        self.cli_init_image = cli_init_image
  
 
     def build(self):
@@ -48,7 +49,7 @@ class RyzerManager:
         """
         buildflags = self.docker_manager.get_build_flags()
         runflags = self.docker_manager.get_run_flags()
-        initimage = self.base_image if self.base_image is not None else self.docker_manager.get_initial_image()
+        initimage = self.cli_init_image if self.cli_init_image is not None else self.docker_manager.get_initial_image()
 
         print(f'Build Flags: {buildflags}')
         print(f'Run Flags:   {runflags}')       


### PR DESCRIPTION
Proposal: Be able to specify a specific ROCm base image to build a Ryzer package with from the command line. A Ryzer package would be built with a base image in the following priority-order (highest to lowest): --base_image from CLI > Ryzer package's config.yaml > RYZERS_DEFAULT_INIT_IMAGE.

Example command: `ryzers build gemma3 --name ryzers-gemma3 --base_path . --base_image "rocm/pytorch:rocm7.1_ubuntu24.04_py3.12_pytorch_release_2.6.0"`

A CLI argument would allow us to test packages with newer ROCm releases and/or automate sweeps of Ryzers packages under different ROCm builds without having to modify config.yaml for each package.