### PR TITLE
Adding HF/transformers API example to gemma3 VLM package

### DIFF
--- a/packages/vlm/gemma3/Dockerfile
+++ b/packages/vlm/gemma3/Dockerfile
@@ -10,8 +10,12 @@ WORKDIR /ryzers
 RUN mkdir -p /ryzers/data/ && \
     wget https://github.com/AMDResearch/Riallto/blob/main/notebooks/images/jpg/toucan.jpg?raw=true -O /ryzers/data/toucan.jpg
 
+# Install python packages (for HF API)
+RUN pip install -U transformers accelerate
+
 # Copy test script
 COPY test.sh /ryzers/test_gemma3.sh
+COPY test_hf.py /ryzers/test_gemma3_hf.py
 COPY demo.sh /ryzers/demo_gemma3.sh
 RUN chmod +x /ryzers/test_gemma3.sh /ryzers/demo_gemma3.sh
 

--- a/packages/vlm/gemma3/README.md
+++ b/packages/vlm/gemma3/README.md
@@ -24,4 +24,17 @@ ryzers run /ryzers/demo_gemma3.sh
 
 In a browser, open file://\<PATH TO REPO\>/index.html
 
+### Build and run with HuggingFace Transformers
+
+gemma3 can also be run with the transformers API. To do so, run:
+
+```
+ryzers build gemma3
+ryzers run bash
+
+# inside docker container
+cd /ryzers
+HSA_OVERRIDE_GFX_VERSION=11.0.0 HF_TOKEN=<your_huggingface_token> python test_gemma3_hf.py
+```
+
 Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/packages/vlm/gemma3/test_hf.py
+++ b/packages/vlm/gemma3/test_hf.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Example adapted from: https://huggingface.co/google/gemma-3-4b-it
+
+from transformers import AutoProcessor, Gemma3ForConditionalGeneration
+import torch
+
+model_id = "google/gemma-3-4b-it"
+
+model = Gemma3ForConditionalGeneration.from_pretrained(
+    model_id, device_map="auto"
+).eval()
+
+processor = AutoProcessor.from_pretrained(model_id)
+
+chat = [
+    {
+        "role": "system",
+        "content": [{"type": "text", "text": "You are a helpful assistant."}]
+    },
+    {
+        "role": "user",
+        "content": [
+            {"type": "image", "image": "/ryzers/data/toucan.jpg"},
+            {"type": "text", "text": "Describe this image in detail."}
+        ]
+    }
+]
+
+inputs = processor.apply_chat_template(
+    chat, add_generation_prompt=True, tokenize=True,
+    return_dict=True, return_tensors="pt"
+).to(model.device, dtype=torch.bfloat16)
+
+input_len = inputs["input_ids"].shape[-1]
+
+with torch.inference_mode():
+    generation = model.generate(**inputs, max_new_tokens=200, do_sample=False)
+    generation = generation[0][input_len:]
+
+decoded = processor.decode(generation, skip_special_tokens=True)
+print(decoded)
+


### PR DESCRIPTION
Added a transformers-based example (`test_hf.py`) for gemma3 package. The Dockerfile and README are both updated as well.