### PR TITLE
patch genesis gstaichi version

### DIFF
--- a/packages/robotics/genesis/Dockerfile
+++ b/packages/robotics/genesis/Dockerfile
@@ -32,7 +32,8 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
 
 # Compatible build: NumPy 2.x with corresponding scikit-image version
 RUN pip3 install --no-cache-dir --break-system-packages "numpy==2.1.2" && \
-    pip3 install --no-cache-dir --break-system-packages "scikit-image==0.24.0"
+    pip3 install --no-cache-dir --break-system-packages "scikit-image==0.24.0" && \
+    pip3 install --no-cache-dir --break-system-packages "matplotlib==3.10.8"
 
 # Genesis and gstaichi (compatible with Genesis 0.3.3; beta release fixes kernel interface mismatch)
 RUN pip3 install --no-cache-dir --break-system-packages "gstaichi==2.5.0" \


### PR DESCRIPTION
Currently Genesis build breaks because gstaichi version 2.5.0b4 seems to have been dropped from pypi? Setting to 2.5.0 seems to fix the issue and test to pass.  