### PR TITLE
openpi patch: pin specific av version in Dockerfile

### DIFF
--- a/packages/vla/openpi/Dockerfile
+++ b/packages/vla/openpi/Dockerfile
@@ -58,6 +58,7 @@ RUN git clone https://github.com/Physical-Intelligence/openpi && \
 COPY openpi.patch /ryzers/openpi
 RUN cd openpi && \
     git apply ./openpi.patch && \
+    sed -i '/^override-dependencies = \[/ s/\]/, "av==13.1.0"]/' pyproject.toml && \
     GIT_LFS_SKIP_SMUDGE=1 uv sync && \
     GIT_LFS_SKIP_SMUDGE=1 uv pip install -e .
 


### PR DESCRIPTION
Openpi uv tries to install av==14.4.0 which causes it to build from source and crash due to various ffmpeg dependencies. Reason is they removed that wheel from pypi. Locking down to 13.1.0 seems to fix this.

Relevant issue: https://github.com/PyAV-Org/PyAV/issues/2084

