### PR TITLE
RAI: patch rocm torch and pin stable commit

### DIFF
--- a/packages/robotics/rai/Dockerfile
+++ b/packages/robotics/rai/Dockerfile
@@ -41,6 +41,7 @@ WORKDIR /ryzers
 RUN git clone https://github.com/RobotecAI/rai.git
 
 WORKDIR /ryzers/rai
+RUN git checkout a097617 # pin working commit
 RUN vcs import < ros_deps.repos
 RUN vcs import < demos.repos
 
@@ -57,6 +58,9 @@ RUN . ./scripts/download_demo.sh manipulation
 # Build ROS 2 packages (need to source ROS environment first)
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
     colcon build --symlink-install
+
+# Re-install torch
+RUN pip install --force-reinstall --no-deps /torch*.whl
 
 # Copy test scripts
 WORKDIR /ryzers

--- a/packages/robotics/rai/config.yaml
+++ b/packages/robotics/rai/config.yaml
@@ -5,7 +5,8 @@ port_mappings:
   - "8501:8501"   # Streamlit frontend
 
 # Uncomment to set your OpenAI API key
-#environment_variables:
+environment_variables:
+- "HSA_OVERRIDE_GFX_VERSION=11.0.0"
 #- "OPENAI_API_KEY=your-api-key-here"
 
 volume_mappings:                                                                                                                                                                      


### PR DESCRIPTION
- poetry nukes pre-installed torch, need to re-install from docker wheels after setup to enable gpu acceleration of cv models
- pinning stable commit for reproducibility