### PR TITLE
upgrade xdna ryzer

### DIFF
--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG DRIVER_VERSION="854ff04"
+ARG DRIVER_VERSION="c8d1727"
 
 # required by rocm driver
 RUN groupadd -f render && usermod -aG render root
@@ -31,10 +31,9 @@ RUN cd /ryzers/xdna-driver/tools && \
 RUN cd /ryzers/xdna-driver/xrt/build/ && \
     ./build.sh -npu -opt -noctest
 
-# Build XDNA driver
+# Build XDNA driver (-release also generates the .deb package)
 RUN cd /ryzers/xdna-driver/build && \
-    ./build.sh -release && \
-    ./build.sh -package
+    ./build.sh -release
 
 # Finally, save and install the XRT/XDNA debian packages
 # these will also need to be installed on the host system

--- a/packages/npu/xdna/README.md
+++ b/packages/npu/xdna/README.md
@@ -8,7 +8,7 @@
 
 **Note:** To run the container you will need to have the XDNA driver installed on your host system as well.
 
-You can install the driver using the [install_xdna.sh](install_xdna.sh) script. Inspect the contents of the script, by setting the `USE_RYZER` option you can either build it nativelly on your host machine or utilize this package to build it in a docker (the default option).
+You can install the driver using the [install_xdna.sh](install_xdna.sh) script. Inspect the contents of the script, by setting the `USE_RYZER` option you can either build it nativelly on your host machine or utilize this package to build it in a docker (the default option). If the host already has an older driver and you are bumping `DRIVER_VERSION`, rerun the script with `FORCE_REINSTALL=true` to rebuild and reinstall.
 
 If you used the `install_xdna.sh` script with the `USE_RYZER` flag, you're ready to run the container with a one-liner.
 
@@ -26,20 +26,24 @@ ryzers run
 By default the docker will run a driver validation script. You should see the following output:
 
 ```
-WARNING: User doesn't have admin permissions to set performance mode. Running validate in Default mode
-Validate Device           : [0000:6a:00.1]
-    Platform              : NPU Phoenix
-    Power Mode            : Default
+WARNING: User doesn't have admin permissions to set performance mode. Running validate in default mode
+Validate Device           : [0000:c6:00.1]
+    Platform              : NPU Strix Halo
+    Power Mode            : default
 -------------------------------------------------------------------------------
-Test 1 [0000:6a:00.1]     : latency                                             
-    Details               : Average latency: 121.3 us
+Test 1 [0000:c6:00.1]     : gemm
+    Details               : TOPS: 51.0
     Test Status           : [PASSED]
 -------------------------------------------------------------------------------
-Test 2 [0000:6a:00.1]     : throughput                                          
-    Details               : Average throughput: 22628.6 ops
+Test 2 [0000:c6:00.1]     : latency
+    Details               : Average latency: 48.0 us
     Test Status           : [PASSED]
 -------------------------------------------------------------------------------
-Validation completed. Please run the command '--verbose' option for more details
+Test 3 [0000:c6:00.1]     : throughput
+    Details               : Average throughput: 72493.0 op/s
+    Test Status           : [PASSED]
+-------------------------------------------------------------------------------
+Validation completed
 ```
 
 ---

--- a/packages/npu/xdna/install_xdna.sh
+++ b/packages/npu/xdna/install_xdna.sh
@@ -5,8 +5,9 @@
 
 set -e
 
-DRIVER_VERSION=51b9400
+DRIVER_VERSION=c8d1727
 USE_RYZER=true
+FORCE_REINSTALL=${FORCE_REINSTALL:-false}
 ROOT_DIR=$(pwd)
 CURRENT_USER=$(whoami)
 
@@ -32,19 +33,18 @@ if [[ "$kernel_version" < "6.10" ]]; then
 fi
 
 # Host machine setup
-if dpkg-query -W xrt_plugin-amdxdna; then
+if dpkg-query -W xrt_plugin-amdxdna 2>/dev/null && ! $FORCE_REINSTALL ; then
     echo "xrt_plugin-amdxdna is already installed, skipping host installs..."
 else
     echo "Installing dependencies"
     sudo apt-get install -y build-essential gcc-x86-64-linux-gnu libgl-dev libxdmcp-dev \
-	    bzip2 libalgorithm-diff-perl libglx-dev lto-disabled-list dkms libalgorithm-diff-xs-perl \
-	    libhwasan0 make dpkg-dev libalgorithm-merge-perl libitm1 ocl-icd-opencl-dev fakeroot libasan8 \
-	    liblsan0 opencl-c-headers g++ libboost-filesystem1.83.0 libquadmath0 opencl-clhpp-headers g++-14 \
-	    libboost-program-options1.83.0 libstdc++-14-dev uuid-dev g++-14-x86-64-linux-gnu libcc1-0 libtsan2 \
-	    x11proto-dev g++-x86-64-linux-gnu libdpkg-perl libubsan1 xorg-sgml-doctools gcc libfakeroot \
-	    libx11-dev xtrans-dev gcc-14 libfile-fcntllock-perl libxau-dev gcc-14-x86-64-linux-gnu \
-	    libgcc-14-dev libxcb1-dev
-    
+           bzip2 libalgorithm-diff-perl libglx-dev lto-disabled-list dkms libalgorithm-diff-xs-perl \
+           libhwasan0 make dpkg-dev libalgorithm-merge-perl libitm1 ocl-icd-opencl-dev fakeroot libasan8 \
+           liblsan0 opencl-c-headers g++ libboost-filesystem1.83.0 libquadmath0 opencl-clhpp-headers g++-14 \
+           libboost-program-options1.83.0 libstdc++-14-dev uuid-dev g++-14-x86-64-linux-gnu libcc1-0 libtsan2 \
+           x11proto-dev g++-x86-64-linux-gnu libdpkg-perl libubsan1 xorg-sgml-doctools gcc libfakeroot \
+           libx11-dev xtrans-dev gcc-14 libfile-fcntllock-perl libxau-dev gcc-14-x86-64-linux-gnu \
+           libgcc-14-dev libxcb1-dev
     if $USE_RYZER ; then
         ryzers build xdna --name xdna
         docker run --rm -v $(pwd):/host_dir xdna:latest bash -c "cp -v /ryzers/debs/*.deb /host_dir/"
@@ -66,8 +66,8 @@ else
         ./build.sh -npu -opt
 
         cd ../../build
+        # -release already generates the .deb package in newer driver versions
         ./build.sh -release
-        ./build.sh -package
 
         # copy generated debs
         cp $ROOT_DIR/xdna-driver/xrt/build/Release/xrt_*-amd64-base.deb $ROOT_DIR/


### PR DESCRIPTION
- Bump xdna driver version to latest: c8d1727
- build -package no longer necessary, release includes debian packages
- Added a FORCE_REINSTALL option to install_xdna script

Tested with rocm7.2.2 and ryzenai_cvml (works without changes)