### PR TITLE
ryzers: fix entrypoint base_path so the CLI works from any directory

### DIFF
--- a/ryzers/__init__.py
+++ b/ryzers/__init__.py
@@ -1,9 +1,20 @@
 # Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+import os
 
-RYZERS_DEFAULT_INIT_IMAGE = "rocm/pytorch:rocm7.0_ubuntu24.04_py3.12_pytorch_release_2.6.0"
+RYZERS_DEFAULT_INIT_IMAGE = "rocm/pytorch:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0"
 RYZERS_DEFAULT_RUN_FLAGS = "-it --rm --shm-size 16G --cap-add=SYS_PTRACE  --network=host --ipc=host"
 
-# This gets populated with path to setup.py during pip install
+# Auto-detect packages path in editable mode
 RYZERS_PACKAGES_PATH = None
+
+# If still None, try to detect from __file__
+if RYZERS_PACKAGES_PATH is None:
+    # In editable install, __file__ points to the source location
+    if __file__:
+        # Go up from ryzers/__init__.py to the repo root
+        _init_path = os.path.dirname(os.path.abspath(__file__))
+        _repo_root = os.path.dirname(_init_path)
+        if os.path.exists(os.path.join(_repo_root, 'packages')):
+            RYZERS_PACKAGES_PATH = _repo_root

--- a/ryzers/entrypoint.py
+++ b/ryzers/entrypoint.py
@@ -6,6 +6,7 @@ import sys
 import argparse
 from .ryzer import RyzerManager
 from .runner import DockerRunner
+from . import RYZERS_PACKAGES_PATH
 
 def build(base_path, name, packages, init_image):
     """
@@ -37,7 +38,9 @@ def main():
 
     Parses command-line arguments and executes the appropriate build or run command.
     """
-    default_base_path = os.getcwd()
+    # Prefer the package-detected path (works regardless of CWD); fall
+    # back to CWD only if detection failed (e.g. zip/wheel install).
+    default_base_path = RYZERS_PACKAGES_PATH or os.getcwd()
 
     parser = argparse.ArgumentParser(description="Command-line tool for building and running Ryzen AI Dockers.")
     

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 from setuptools import setup, find_packages
-import os
-
-# Path to the directory of this setup.py file
-setup_dir = os.path.dirname(os.path.abspath(__file__))
-
-# Path to the ryzers package
-ryzer_dir = os.path.join(setup_dir, 'ryzers')
-
-# Path to the __init__.py file in the ryzers package
-init_file = os.path.join(ryzer_dir, '__init__.py')
-
-if os.name == 'nt':  # Windows
-    setup_dir = setup_dir.replace('\\', '\\\\')
-
-
-# Read the current contents of the file
-with open(init_file, 'r') as file:
-    lines = file.readlines()
-
-# Modify the line starting with RYZER_PACKAGES_PATH =
-with open(init_file, 'w') as file:
-    for line in lines:
-        if line.startswith('RYZER_PACKAGES_PATH ='):
-            line = f'RYZER_PACKAGES_PATH = "{setup_dir}"\n'
-        file.write(line)
 
 setup(
     name="ryzers",
@@ -48,4 +23,3 @@ setup(
     ],
     python_requires='>=3.8',
 )
-


### PR DESCRIPTION
`ryzers build <pkg>` invoked from any directory other than the repo root fails with `FileNotFoundError: Cannot find required package: ryzer_env` because ryzers/entrypoint.py defaults base_path to os.getcwd() and the lookup for packages/init/ryzer_env then misses.

A previous attempt added auto-detection of `RYZERS_PACKAGES_PATH` in ryzers/__init__.py and a setup.py post-install hook that was supposed to hardcode the path on installation. That hook is a no-op for `pip install -e .` (editable installs do not run install_lib hooks for package data) and the entrypoint never reads the env var anyway.

* ryzers/entrypoint.py: default base_path to RYZERS_PACKAGES_PATH or os.getcwd() so the CLI works from any directory regardless of how ryzers was installed
* ryzers/__init__.py: clean RYZERS_PACKAGES_PATH auto-detection from __file__ for editable installs (no post-install steps required)
* setup.py: drop the broken post-install path-injection block