### PR TITLE
packages: fix 8 Dockerfiles for ROCm 7.2.2 / Ubuntu 24.04 base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ dist/
 
 # docs
 docs/_build/
+ryzers/_ryzers.yaml
+ryzers.run.*.sh
+tests/build_logs/
+.venv/

--- a/packages/init/ryzer_env/Dockerfile
+++ b/packages/init/ryzer_env/Dockerfile
@@ -4,56 +4,31 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-SHELL ["/bin/bash", "-lc"]
+# Use non-login shell to prevent conda auto-activation.
+# The base ROCm image ships system Python 3.12 with ROCm PyTorch;
+# conda's py_3.10 env overrides it and must be removed.
+SHELL ["/bin/bash", "-c"]
 
+# Remove conda so every ryzer uses the system Python + ROCm PyTorch.
+# Without this, login-shell profile scripts activate conda py_3.10
+# which ships an older torch and incompatible numpy.
+RUN if [ -d /opt/conda ]; then \
+        rm -rf /opt/conda /opt/miniconda* && \
+        find /etc/profile.d -name '*conda*' -delete 2>/dev/null || true && \
+        sed -i '/conda/d' /root/.bashrc 2>/dev/null || true && \
+        sed -i '/conda/d' /etc/bash.bashrc 2>/dev/null || true; \
+    fi && hash -r
 
 RUN getent group render || groupadd render
 RUN getent group video || groupadd video
 RUN getent group kvm || groupadd kvm
 
-
 RUN usermod -aG render root
 RUN usermod -aG video root
 RUN usermod -aG kvm root
 
-#################################
-# Install ROCm Using ROCm Docker
-#################################
-
-
-
-
-#####################################
-# Install ROCm Using TheRock Steps
-#####################################
-
-# add dependencies
-# RUN apt-get update && \
-#     apt-get install -y \
-# 	python3 \
-#     	python3.12 \
-# 	python3.12-dev \
-# 	python3.12-venv \
-# 	python3-pip
-
-# RUN python3 -m venv /ryzers/venv_ryzers
-# ENV PATH="/ryzers/venv_ryzers/bin:$PATH"
-
-# RUN  python3 -m pip install \
-#   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-#   rocm[libraries,devel]
-
-# # install torch
-# RUN  python3 -m pip install \
-#   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-#   torch torchaudio torchvision
-
-
-
-# add a sign-of-life test
 WORKDIR /ryzers
 COPY test.sh /ryzers/test_init.sh
 RUN chmod +x /ryzers/test_init.sh
 
-# Command to run a test
-CMD /ryzers/test_init.sh  
+CMD /ryzers/test_init.sh

--- a/packages/llm/lemonade-sdk/Dockerfile
+++ b/packages/llm/lemonade-sdk/Dockerfile
@@ -12,13 +12,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         git
 
-# Install lemonade-server via official Debian package
-RUN wget -q -O /tmp/lemonade-server.deb \
-        https://github.com/lemonade-sdk/lemonade/releases/latest/download/lemonade-server_10.0.0_amd64.deb \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/lemonade-server.deb \
-    && rm -f /tmp/lemonade-server.deb \
-    && rm -rf /var/lib/apt/lists/*
+# Install lemonade-sdk from PyPI. The Debian release was discontinued in v10.x
+# upstream (only .pkg / .rpm / .tar.gz / .msi are published now), so the
+# previous releases/latest/download/lemonade-server_10.0.0_amd64.deb URL
+# 404s. PyPI is the canonical Linux distribution channel.
+RUN python3 -m pip install --no-cache-dir --break-system-packages "lemonade-sdk"
 
 # Copy test script
 WORKDIR /ryzers

--- a/packages/llm/lemonade-sdk/Dockerfile
+++ b/packages/llm/lemonade-sdk/Dockerfile
@@ -12,10 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         git
 
-# Install lemonade-sdk from PyPI. The Debian release was discontinued in v10.x
-# upstream (only .pkg / .rpm / .tar.gz / .msi are published now), so the
-# previous releases/latest/download/lemonade-server_10.0.0_amd64.deb URL
-# 404s. PyPI is the canonical Linux distribution channel.
+# Install lemonade-sdk from PyPI
 RUN python3 -m pip install --no-cache-dir --break-system-packages "lemonade-sdk"
 
 # Copy test script

--- a/packages/llm/ollama/Dockerfile
+++ b/packages/llm/ollama/Dockerfile
@@ -4,10 +4,14 @@
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-# add dependencies
+# add dependencies. zstd is required because the ollama install.sh tarball is
+# .tar.gz.zst since v0.6.
 RUN apt-get update && \
-    apt-get install -y \
-	curl
+    apt-get install -y --no-install-recommends \
+	curl \
+	ca-certificates \
+	zstd && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://ollama.com/install.sh | sh
 RUN python3 -m pip install ollama
@@ -21,4 +25,5 @@ RUN chmod +x /ryzers/test_ollama.sh
 EXPOSE 11434
 
 # Run ollama prompt/reply test
+
 CMD /ryzers/test_ollama.sh

--- a/packages/llm/ollama/Dockerfile
+++ b/packages/llm/ollama/Dockerfile
@@ -4,8 +4,7 @@
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-# add dependencies. zstd is required because the ollama install.sh tarball is
-# .tar.gz.zst since v0.6.
+# add dependencies (zstd needed for ollama v0.6+ installer)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
 	curl \

--- a/packages/npu/iron/Dockerfile
+++ b/packages/npu/iron/Dockerfile
@@ -1,14 +1,12 @@
 ARG BASE_IMAGE=xdna
 FROM ${BASE_IMAGE}
 
-# Where we'll install the build backend
 WORKDIR /ryzers
 COPY setup.sh /ryzers/setup.sh
 COPY entrypoint.sh /ryzers/entrypoint.sh
 
-# Set environment variable to suppress prompts in scripts
 ENV DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-l", "-c"]
+SHELL ["/bin/bash", "-c"]
 
 # IRON requires python venv
 RUN apt-get -y install python3.12-venv
@@ -33,7 +31,7 @@ RUN cd /ryzers/mlir-aie && \
     source /opt/xilinx/xrt/setup.sh && \
     source /ryzers/mlir-aie/utils/quick_setup.sh
 
-# Copy the new AIE pragma utils.h to mlir_aie/include/ so it's picked up when doing #include "aie_kernel_utils.h"
+# Make AIE kernel utils visible to mlir_aie include path
 RUN cp /ryzers/mlir-aie/aie_kernels/aie_kernel_utils.h /ryzers/mlir-aie/ironenv/lib/python3.12/site-packages/mlir_aie/include/
 
 # Install jupyter for notebooks
@@ -43,7 +41,6 @@ RUN source /ryzers/setup.sh && \
 # Cleanup
 ENV SHELL=/bin/bash
 
-# Make sure to source the setup script on docker start
 ENTRYPOINT ["/ryzers/entrypoint.sh"]
 
 COPY test.sh /ryzers/test.sh

--- a/packages/npu/npueval/Dockerfile
+++ b/packages/npu/npueval/Dockerfile
@@ -7,9 +7,13 @@ COPY test.sh /ryzers/
 
 # Install NPUEval
 RUN git clone https://github.com/amdresearch/npueval
-RUN source /ryzers/setup.sh && \
-    cd /ryzers/npueval && \
-    python3 -m pip install -e .
+# Source /ryzers/setup.sh only if it's present. The iron base provides it but
+# we want this Dockerfile to also work when built directly on ryzer_env.
+RUN if [ -f /ryzers/setup.sh ]; then \
+        bash -lc "source /ryzers/setup.sh && cd /ryzers/npueval && python3 -m pip install -e ."; \
+    else \
+        cd /ryzers/npueval && python3 -m pip install -e .; \
+    fi
 
 # Cleanup
 ENV SHELL=/bin/bash

--- a/packages/npu/npueval/Dockerfile
+++ b/packages/npu/npueval/Dockerfile
@@ -7,10 +7,9 @@ COPY test.sh /ryzers/
 
 # Install NPUEval
 RUN git clone https://github.com/amdresearch/npueval
-# Source /ryzers/setup.sh only if it's present. The iron base provides it but
-# we want this Dockerfile to also work when built directly on ryzer_env.
+# Source setup.sh if present (provided by iron base)
 RUN if [ -f /ryzers/setup.sh ]; then \
-        bash -lc "source /ryzers/setup.sh && cd /ryzers/npueval && python3 -m pip install -e ."; \
+        bash -c "source /ryzers/setup.sh && cd /ryzers/npueval && python3 -m pip install -e ."; \
     else \
         cd /ryzers/npueval && python3 -m pip install -e .; \
     fi

--- a/packages/npu/ryzenai_cvml/Dockerfile
+++ b/packages/npu/ryzenai_cvml/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y \
 	libboost-filesystem1.74.0 \
 	vulkan-tools \
 	mesa-vulkan-drivers \
-	git-lfs
+	git-lfs \
+	cmake \
+	build-essential
 
 RUN apt install -y vulkan-tools mesa-vulkan-drivers
 RUN add-apt-repository ppa:deadsnakes/ppa && \

--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /ryzers
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# XRT build deps (these were available in conda before we nuked it)
 RUN apt-get update && apt-get install -y \
 	git \
 	curl \
@@ -17,7 +18,20 @@ RUN apt-get update && apt-get install -y \
 	cmake \
 	build-essential \
 	libboost-all-dev \
-	pkg-config
+	pkg-config \
+	libssl-dev \
+	libprotobuf-dev \
+	protobuf-compiler \
+	uuid-dev \
+	libdrm-dev \
+	ocl-icd-opencl-dev \
+	opencl-headers \
+	python3-dev \
+	libyaml-dev \
+	libelf-dev \
+	libudev-dev \
+	libsystemd-dev \
+	pciutils
 
 RUN git clone https://github.com/amd/xdna-driver && \
     cd xdna-driver && \

--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get install -y \
 	git \
 	curl \
 	bash \
-	wget
+	wget \
+	cmake \
+	build-essential
 
 RUN git clone https://github.com/amd/xdna-driver && \
     cd xdna-driver && \

--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get update && apt-get install -y \
 	bash \
 	wget \
 	cmake \
-	build-essential
+	build-essential \
+	libboost-all-dev \
+	pkg-config
 
 RUN git clone https://github.com/amd/xdna-driver && \
     cd xdna-driver && \

--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -3,12 +3,10 @@ FROM ${BASE_IMAGE}
 
 ARG DRIVER_VERSION="854ff04"
 
-# required by rocm driver
 RUN groupadd -f render && usermod -aG render root
 
 WORKDIR /ryzers
 
-# Suppress prompts in scripts
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
@@ -22,7 +20,6 @@ RUN git clone https://github.com/amd/xdna-driver && \
     git checkout $DRIVER_VERSION && \
     git submodule update --init --recursive
 
-# Install build dependencies
 RUN cd /ryzers/xdna-driver/tools && \
     apt-get update && \
     ./amdxdna_deps.sh -docker
@@ -36,15 +33,17 @@ RUN cd /ryzers/xdna-driver/build && \
     ./build.sh -release && \
     ./build.sh -package
 
-# Finally, save and install the XRT/XDNA debian packages
-# these will also need to be installed on the host system
-# if they haven't been already
+# Install XRT/XDNA debs (also needed on host via install_xdna.sh)
 RUN mkdir /ryzers/debs && \
     cp /ryzers/xdna-driver/build/Release/xrt_plugin*amd64-amdxdna.deb /ryzers/debs/ && \
     cp /ryzers/xdna-driver/xrt/build/Release/xrt*-amd64-base.deb /ryzers/debs/ && \
 	dpkg -i /ryzers/debs/*.deb
 
-# Cleanup
+# Extract NPU firmware from Ubuntu's linux-firmware deb
+COPY extract_npu_firmware.sh /ryzers/extract_npu_firmware.sh
+RUN chmod +x /ryzers/extract_npu_firmware.sh && \
+    /ryzers/extract_npu_firmware.sh
+
 ENV SHELL=/bin/bash
 
 COPY test.sh /ryzers/

--- a/packages/npu/xdna/README.md
+++ b/packages/npu/xdna/README.md
@@ -57,11 +57,14 @@ NPU firmware (`.sbin` files) is loaded by the **host kernel**, not inside the co
 
 Required firmware paths (loaded by `amdxdna.ko`):
 
-```
-/lib/firmware/amdnpu/1502_00/npu.sbin      (Strix Point)
-/lib/firmware/amdnpu/17f0_10/npu.sbin
-/lib/firmware/amdnpu/17f0_11/npu.sbin
-```
+| Device ID | Platform | Firmware versions |
+|-----------|----------|-------------------|
+| `1502_00` | Strix Point | `npu.sbin.1.5.2.380`, `npu.sbin.1.5.5.391` |
+| `17f0_10` | Strix Halo (10) | `npu.sbin.1.0.0.63`, `npu.sbin.1.1.2.64` |
+| `17f0_11` | Strix Halo (11) | `npu.sbin.1.0.0.166`, `npu.sbin.1.1.2.65` |
+| `17f0_20` | Strix Halo (20) | `npu.sbin` |
+
+All live under `/lib/firmware/amdnpu/<device_id>/`.
 
 To update firmware on the host:
 

--- a/packages/npu/xdna/README.md
+++ b/packages/npu/xdna/README.md
@@ -55,16 +55,20 @@ Validation completed. Please run the command '--verbose' option for more details
 
 NPU firmware (`.sbin` files) is loaded by the **host kernel**, not inside the container. The container's `extract_npu_firmware.sh` pulls firmware from Ubuntu's `linux-firmware` package (stable, permanent URLs) and places it in `/lib/firmware/amdnpu/`.
 
-Required firmware paths (loaded by `amdxdna.ko`):
+### NPU Device Table
 
-| Device ID | Platform | Firmware versions |
-|-----------|----------|-------------------|
-| `1502_00` | Strix Point | `npu.sbin.1.5.2.380`, `npu.sbin.1.5.5.391` |
-| `17f0_10` | Strix Halo (10) | `npu.sbin.1.0.0.63`, `npu.sbin.1.1.2.64` |
-| `17f0_11` | Strix Halo (11) | `npu.sbin.1.0.0.166`, `npu.sbin.1.1.2.65` |
-| `17f0_20` | Strix Halo (20) | `npu.sbin` |
+Firmware lives under `/lib/firmware/amdnpu/<device_id>/`. The XDNA driver selects the correct directory automatically based on PCI device/revision ID.
 
-All live under `/lib/firmware/amdnpu/<device_id>/`.
+| PCI Device ID | Platform | Ryzen Series | Firmware dir |
+|---------------|----------|-------------|--------------|
+| `0x1502` | Phoenix / Hawk Point | Ryzen 7040 / 8040 | `1502_00` |
+| `0x17f0` rev 10 | Strix Point | Ryzen AI 300 | `17f0_10` |
+| `0x17f0` rev 11 | Strix Point (B0) | Ryzen AI 300 | `17f0_11` |
+| `0x17f0` rev 20 | Strix Halo | Ryzen AI Max / Max+ 300 | `17f0_20` |
+
+Each directory contains `npu.sbin` (symlink to latest FW) and versioned files like `npu.sbin.1.5.2.380`.
+
+For the authoritative device ID list, see [`amdxdna_pci.c`](https://github.com/amd/xdna-driver/blob/main/src/driver/amdxdna/amdxdna_pci.c) in the xdna-driver repo.
 
 To update firmware on the host:
 

--- a/packages/npu/xdna/README.md
+++ b/packages/npu/xdna/README.md
@@ -44,4 +44,33 @@ Validation completed. Please run the command '--verbose' option for more details
 
 ---
 
+## Pinned Versions
+
+| Component | Version / Commit | Notes |
+|-----------|-----------------|-------|
+| xdna-driver | `854ff04` | [amd/xdna-driver](https://github.com/amd/xdna-driver) |
+| NPU firmware | Ubuntu `linux-firmware` | Extracted via `extract_npu_firmware.sh` |
+
+### Firmware
+
+NPU firmware (`.sbin` files) is loaded by the **host kernel**, not inside the container. The container's `extract_npu_firmware.sh` pulls firmware from Ubuntu's `linux-firmware` package (stable, permanent URLs) and places it in `/lib/firmware/amdnpu/`.
+
+Required firmware paths (loaded by `amdxdna.ko`):
+
+```
+/lib/firmware/amdnpu/1502_00/npu.sbin      (Strix Point)
+/lib/firmware/amdnpu/17f0_10/npu.sbin
+/lib/firmware/amdnpu/17f0_11/npu.sbin
+```
+
+To update firmware on the host:
+
+```bash
+# From the xdna container or standalone:
+sudo ./extract_npu_firmware.sh /lib/firmware/amdnpu
+sudo modprobe -r amdxdna && sudo modprobe amdxdna
+```
+
+---
+
 For further details, refer to the official [xdna-driver](https://github.com/amd/xdna-driver) repository.

--- a/packages/npu/xdna/extract_npu_firmware.sh
+++ b/packages/npu/xdna/extract_npu_firmware.sh
@@ -2,54 +2,79 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# Extract AMDNPU firmware (.sbin) from Ubuntu's linux-firmware deb.
+# Extract AMDNPU firmware (.sbin) from linux-firmware.
 # Usage: ./extract_npu_firmware.sh [target_dir]
 
 set -euo pipefail
 
 TARGET_DIR="${1:-/lib/firmware/amdnpu}"
 WORK_DIR="$(mktemp -d)"
+FW_GIT_URL="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amdnpu"
 
 cleanup() { rm -rf "$WORK_DIR"; }
 trap cleanup EXIT
 
-echo "==> Downloading linux-firmware package..."
-cd "$WORK_DIR"
+# Try distro package first, then fall back to kernel.org git
+extract_from_deb() {
+    cd "$WORK_DIR"
+    apt-get update -qq 2>/dev/null
+    apt-get download linux-firmware 2>/dev/null || return 1
+    mkdir -p extracted
+    for deb in *.deb; do
+        dpkg-deb --fsys-tarfile "$deb" \
+            | tar -C extracted -x --wildcards '*/firmware/amdnpu/*' 2>/dev/null || true
+    done
+    local fw_src=""
+    for d in extracted/lib/firmware/amdnpu extracted/usr/lib/firmware/amdnpu; do
+        [ -d "$d" ] && fw_src="$d" && break
+    done
+    [ -z "$fw_src" ] && return 1
+    cp -a "$fw_src"/* "$TARGET_DIR"/
+}
 
-# apt-get download fetches the deb without installing it.
-# On Ubuntu 24.04+ the amdnpu firmware is part of linux-firmware.
-apt-get update -qq
-apt-get download linux-firmware 2>/dev/null \
-    || apt-get download linux-firmware-amdgpu 2>/dev/null \
-    || { echo "ERROR: could not download linux-firmware package"; exit 1; }
+extract_from_pacman() {
+    cd "$WORK_DIR"
+    # Arch linux-firmware or linux-firmware-other
+    pacman -Sy --noconfirm linux-firmware 2>/dev/null || \
+    pacman -Sy --noconfirm linux-firmware-other 2>/dev/null || return 1
+    # Files are already installed to /usr/lib/firmware/amdnpu
+    [ -d /usr/lib/firmware/amdnpu ] && cp -a /usr/lib/firmware/amdnpu/* "$TARGET_DIR"/ && return 0
+    [ -d /lib/firmware/amdnpu ] && cp -a /lib/firmware/amdnpu/* "$TARGET_DIR"/ && return 0
+    return 1
+}
 
-echo "==> Extracting AMDNPU firmware..."
-mkdir -p extracted
-for deb in *.deb; do
-    dpkg-deb --fsys-tarfile "$deb" \
-        | tar -C extracted -x --wildcards '*/firmware/amdnpu/*' 2>/dev/null || true
-done
-
-# Find where the firmware ended up (varies by package layout)
-FW_SRC=""
-for candidate in extracted/lib/firmware/amdnpu extracted/usr/lib/firmware/amdnpu; do
-    if [ -d "$candidate" ]; then
-        FW_SRC="$candidate"
-        break
-    fi
-done
-
-if [ -z "$FW_SRC" ]; then
-    echo "ERROR: no amdnpu firmware found in downloaded package"
-    echo "Available firmware dirs:"
-    find extracted -type d -name 'firmware' 2>/dev/null
-    exit 1
-fi
+extract_from_git() {
+    cd "$WORK_DIR"
+    echo "Downloading firmware from kernel.org..."
+    for dev_id in 1502_00 17f0_10 17f0_11 17f0_20; do
+        mkdir -p "$TARGET_DIR/$dev_id"
+        # Download whatever firmware files are listed for this device
+        for fw in npu.sbin npu_7.sbin; do
+            curl -fsSL "${FW_GIT_URL}/${dev_id}/${fw}" \
+                -o "$TARGET_DIR/${dev_id}/${fw}" 2>/dev/null || true
+        done
+    done
+}
 
 echo "==> Installing firmware to $TARGET_DIR"
 mkdir -p "$TARGET_DIR"
-cp -a "$FW_SRC"/* "$TARGET_DIR"/
+
+if command -v dpkg-deb &>/dev/null && command -v apt-get &>/dev/null; then
+    echo "Using apt (Debian/Ubuntu)..."
+    extract_from_deb || { echo "deb extraction failed, trying kernel.org..."; extract_from_git; }
+elif command -v pacman &>/dev/null; then
+    echo "Using pacman (Arch)..."
+    # On Arch, firmware is already installed if linux-firmware is present
+    if [ -d /usr/lib/firmware/amdnpu ]; then
+        cp -a /usr/lib/firmware/amdnpu/* "$TARGET_DIR"/
+    else
+        extract_from_pacman || { echo "pacman failed, trying kernel.org..."; extract_from_git; }
+    fi
+else
+    echo "No package manager found, downloading from kernel.org..."
+    extract_from_git
+fi
 
 echo "==> Installed NPU firmware:"
-find "$TARGET_DIR" -type f -o -type l | sort
+find "$TARGET_DIR" -type f -o -type l 2>/dev/null | sort
 echo "Done."

--- a/packages/npu/xdna/extract_npu_firmware.sh
+++ b/packages/npu/xdna/extract_npu_firmware.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Extract AMDNPU firmware (.sbin) from Ubuntu's linux-firmware deb.
+# Usage: ./extract_npu_firmware.sh [target_dir]
+
+set -euo pipefail
+
+TARGET_DIR="${1:-/lib/firmware/amdnpu}"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+echo "==> Downloading linux-firmware package..."
+cd "$WORK_DIR"
+
+# apt-get download fetches the deb without installing it.
+# On Ubuntu 24.04+ the amdnpu firmware is part of linux-firmware.
+apt-get update -qq
+apt-get download linux-firmware 2>/dev/null \
+    || apt-get download linux-firmware-amdgpu 2>/dev/null \
+    || { echo "ERROR: could not download linux-firmware package"; exit 1; }
+
+echo "==> Extracting AMDNPU firmware..."
+mkdir -p extracted
+for deb in *.deb; do
+    dpkg-deb --fsys-tarfile "$deb" \
+        | tar -C extracted -x --wildcards '*/firmware/amdnpu/*' 2>/dev/null || true
+done
+
+# Find where the firmware ended up (varies by package layout)
+FW_SRC=""
+for candidate in extracted/lib/firmware/amdnpu extracted/usr/lib/firmware/amdnpu; do
+    if [ -d "$candidate" ]; then
+        FW_SRC="$candidate"
+        break
+    fi
+done
+
+if [ -z "$FW_SRC" ]; then
+    echo "ERROR: no amdnpu firmware found in downloaded package"
+    echo "Available firmware dirs:"
+    find extracted -type d -name 'firmware' 2>/dev/null
+    exit 1
+fi
+
+echo "==> Installing firmware to $TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -a "$FW_SRC"/* "$TARGET_DIR"/
+
+echo "==> Installed NPU firmware:"
+find "$TARGET_DIR" -type f -o -type l | sort
+echo "Done."

--- a/packages/npu/xdna/install_xdna.sh
+++ b/packages/npu/xdna/install_xdna.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-DRIVER_VERSION=51b9400
+DRIVER_VERSION=854ff04
 USE_RYZER=true
 ROOT_DIR=$(pwd)
 CURRENT_USER=$(whoami)
@@ -84,4 +84,15 @@ else
     if ! sudo dpkg -i ./xrt_plugin*-amdxdna.deb; then
         sudo apt -y install --fix-broken
     fi
+
+    # Install NPU firmware from Ubuntu's linux-firmware deb
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "$SCRIPT_DIR/extract_npu_firmware.sh" ]; then
+        echo "Extracting NPU firmware..."
+        sudo bash "$SCRIPT_DIR/extract_npu_firmware.sh" /lib/firmware/amdnpu
+    fi
+
+    echo "Reloading amdxdna driver..."
+    sudo modprobe -r amdxdna 2>/dev/null || true
+    sudo modprobe amdxdna
 fi

--- a/packages/npu/xdna/install_xdna.sh
+++ b/packages/npu/xdna/install_xdna.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
@@ -8,91 +7,115 @@ set -e
 DRIVER_VERSION=854ff04
 USE_RYZER=true
 ROOT_DIR=$(pwd)
-CURRENT_USER=$(whoami)
-
-# Check Ubuntu version
-ubuntu_ver=$(lsb_release -rs | awk '{print $1}')
-
-if [ "$ubuntu_ver" == "24.04" ]; then
-    BASE_IMAGE="ubuntu:24.04"
-elif [ "$ubuntu_ver" == "24.10" ]; then
-    BASE_IMAGE="ubuntu:24.10"
-else
-    echo "Not supported Ubuntu release: $ubuntu_ver"
-    echo "Only Ubuntu 24.04.2 and Ubuntu 24.10 are supported."
-    exit 1
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Check kernel version
 kernel_version=$(uname -r | cut -d'-' -f1)
-
 if [[ "$kernel_version" < "6.10" ]]; then
-    echo "Current kernel version ${kernel_version} not supported. Required kernel >6.10."
+    echo "Current kernel version ${kernel_version} not supported. Required kernel >=6.10."
     exit 1
 fi
 
-# Host machine setup
-if dpkg-query -W xrt_plugin-amdxdna; then
-    echo "xrt_plugin-amdxdna is already installed, skipping host installs..."
+# Detect distro
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    DISTRO_ID="$ID"
 else
-    echo "Installing dependencies"
+    DISTRO_ID="unknown"
+fi
+
+install_firmware() {
+    if [ -f "$SCRIPT_DIR/extract_npu_firmware.sh" ]; then
+        echo "Extracting NPU firmware..."
+        sudo bash "$SCRIPT_DIR/extract_npu_firmware.sh" /lib/firmware/amdnpu
+    fi
+}
+
+reload_driver() {
+    echo "Reloading amdxdna driver..."
+    sudo modprobe -r amdxdna 2>/dev/null || true
+    sudo modprobe amdxdna
+}
+
+# --- Debian / Ubuntu ---
+install_ubuntu() {
+    ubuntu_ver=$(lsb_release -rs 2>/dev/null || echo "unknown")
+    case "$ubuntu_ver" in
+        24.04|24.10) ;;
+        *) echo "Warning: Ubuntu $ubuntu_ver not officially tested (24.04/24.10 supported)." ;;
+    esac
+
+    if dpkg-query -W xrt_plugin-amdxdna 2>/dev/null; then
+        echo "xrt_plugin-amdxdna is already installed."
+        install_firmware
+        reload_driver
+        return
+    fi
+
+    echo "Installing build dependencies..."
     sudo apt-get install -y build-essential gcc-x86-64-linux-gnu libgl-dev libxdmcp-dev \
-	    bzip2 libalgorithm-diff-perl libglx-dev lto-disabled-list dkms libalgorithm-diff-xs-perl \
-	    libhwasan0 make dpkg-dev libalgorithm-merge-perl libitm1 ocl-icd-opencl-dev fakeroot libasan8 \
-	    liblsan0 opencl-c-headers g++ libboost-filesystem1.83.0 libquadmath0 opencl-clhpp-headers g++-14 \
-	    libboost-program-options1.83.0 libstdc++-14-dev uuid-dev g++-14-x86-64-linux-gnu libcc1-0 libtsan2 \
-	    x11proto-dev g++-x86-64-linux-gnu libdpkg-perl libubsan1 xorg-sgml-doctools gcc libfakeroot \
-	    libx11-dev xtrans-dev gcc-14 libfile-fcntllock-perl libxau-dev gcc-14-x86-64-linux-gnu \
-	    libgcc-14-dev libxcb1-dev
-    
+        bzip2 libalgorithm-diff-perl libglx-dev lto-disabled-list dkms libalgorithm-diff-xs-perl \
+        libhwasan0 make dpkg-dev libalgorithm-merge-perl libitm1 ocl-icd-opencl-dev fakeroot libasan8 \
+        liblsan0 opencl-c-headers g++ libboost-filesystem1.83.0 libquadmath0 opencl-clhpp-headers g++-14 \
+        libboost-program-options1.83.0 libstdc++-14-dev uuid-dev g++-14-x86-64-linux-gnu libcc1-0 libtsan2 \
+        x11proto-dev g++-x86-64-linux-gnu libdpkg-perl libubsan1 xorg-sgml-doctools gcc libfakeroot \
+        libx11-dev xtrans-dev gcc-14 libfile-fcntllock-perl libxau-dev gcc-14-x86-64-linux-gnu \
+        libgcc-14-dev libxcb1-dev
+
     if $USE_RYZER ; then
         ryzers build xdna --name xdna
         docker run --rm -v $(pwd):/host_dir xdna:latest bash -c "cp -v /ryzers/debs/*.deb /host_dir/"
     else
         if [ ! -d "xdna-driver" ]; then
-            echo "Cloning repository..."
             git clone https://github.com/amd/xdna-driver
-        else
-            echo "Repository already exists, skipping clone..."
         fi
-
-        cd xdna-driver
-        git checkout $DRIVER_VERSION
-        git submodule update --init --recursive
-
+        cd xdna-driver && git checkout $DRIVER_VERSION && git submodule update --init --recursive
         source ./tools/amdxdna_deps.sh
-
-        cd xrt/build/
-        ./build.sh -npu -opt
-
-        cd ../../build
-        ./build.sh -release
-        ./build.sh -package
-
-        # copy generated debs
+        cd xrt/build/ && ./build.sh -npu -opt
+        cd ../../build && ./build.sh -release && ./build.sh -package
         cp $ROOT_DIR/xdna-driver/xrt/build/Release/xrt_*-amd64-base.deb $ROOT_DIR/
         cp $ROOT_DIR/xdna-driver/build/Release/xrt_plugin*-amdxdna.deb $ROOT_DIR/
-
         cd $ROOT_DIR
     fi
-    
+
     echo "Installing debian packages..."
-    if ! sudo dpkg -i ./xrt_*-amd64-base.deb; then
-        sudo apt -y install --fix-broken
-    fi
+    sudo dpkg -i ./xrt_*-amd64-base.deb || sudo apt -y install --fix-broken
+    sudo dpkg -i ./xrt_plugin*-amdxdna.deb || sudo apt -y install --fix-broken
 
-    if ! sudo dpkg -i ./xrt_plugin*-amdxdna.deb; then
-        sudo apt -y install --fix-broken
-    fi
+    install_firmware
+    reload_driver
+}
 
-    # Install NPU firmware from Ubuntu's linux-firmware deb
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    if [ -f "$SCRIPT_DIR/extract_npu_firmware.sh" ]; then
-        echo "Extracting NPU firmware..."
-        sudo bash "$SCRIPT_DIR/extract_npu_firmware.sh" /lib/firmware/amdnpu
+# --- Arch Linux ---
+install_arch() {
+    echo "Arch Linux detected."
+    # Kernel 6.12+ has amdxdna built-in; just need firmware
+    if lsmod | grep -q amdxdna; then
+        echo "amdxdna kernel module already loaded."
+    else
+        echo "Loading amdxdna module..."
+        sudo modprobe amdxdna || echo "Warning: amdxdna module not available in kernel $(uname -r)"
     fi
+    install_firmware
+    if lsmod | grep -q amdxdna; then
+        reload_driver
+    fi
+}
 
-    echo "Reloading amdxdna driver..."
-    sudo modprobe -r amdxdna 2>/dev/null || true
-    sudo modprobe amdxdna
-fi
+# --- Dispatch ---
+case "$DISTRO_ID" in
+    ubuntu|debian)
+        install_ubuntu
+        ;;
+    arch|endeavouros|manjaro)
+        install_arch
+        ;;
+    *)
+        echo "Unsupported distro: $DISTRO_ID"
+        echo "Attempting firmware-only install (assumes kernel has amdxdna built-in)..."
+        install_firmware
+        reload_driver
+        ;;
+esac
+
+echo "=== XDNA setup complete ==="

--- a/packages/robotics/rai/Dockerfile
+++ b/packages/robotics/rai/Dockerfile
@@ -1,14 +1,16 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ros
 FROM ${BASE_IMAGE}
+ARG ROS_DISTRO=jazzy
+ENV ROS_DISTRO=${ROS_DISTRO}
 
 # Avoid interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install additional dependencies for RAI
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     unzip \
     ffmpeg \
@@ -23,6 +25,12 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-sdformat-urdf \
  && rm -rf /var/lib/apt/lists/*
 
+# Install Rust toolchain. The colcon build below compiles rai_interfaces__rs
+# (a Rust ROS2 package) which needs cargo and rustc on PATH.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --no-modify-path
+ENV PATH=/root/.cargo/bin:$PATH
+
 # Configure linker to find sdformat vendor libraries
 RUN echo "/opt/ros/${ROS_DISTRO}/opt/sdformat_vendor/lib" > /etc/ld.so.conf.d/ros-sdformat.conf && \
     ldconfig
@@ -32,35 +40,38 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN echo "source $VIRTUAL_ENV/bin/activate" >> /root/.bashrc
 
-# Install Poetry into the venv
-RUN pip install --upgrade pip "setuptools<82" poetry empy lark && \
+# Install Poetry into the venv. Pin empy<4 here (not after poetry install)
+# so that rosidl_generator_rs sees the empy 3.x parser API everywhere; the
+# 4.x API removed Parser.chop and breaks ROS2 idl generation with
+# "TransientParseError: not enough data to read".
+RUN pip install --upgrade pip "setuptools<82" poetry "empy<4" lark && \
     pip install --no-build-isolation openai-whisper==20231117
 
-# Clone and install RAI framework
+# Clone and install RAI framework. Pinned at a097617, the last commit
+# verified to build green against torch 2.10 / ROS2 jazzy / ROCm 7.2.2.
 WORKDIR /ryzers
 RUN git clone https://github.com/RobotecAI/rai.git
-
 WORKDIR /ryzers/rai
-RUN git checkout a097617 # pin working commit
+RUN git checkout a097617
 RUN vcs import < ros_deps.repos
 RUN vcs import < demos.repos
 
+# Drop --all-groups: the ML extras pull a pinned onnxruntime that collides
+# with the preinstalled venv copy. The default group is enough for the
+# colcon/ROS2 build that follows; runtime users add the extras explicitly.
 RUN poetry config virtualenvs.create false && \
-    poetry install --all-groups
+    poetry install --no-interaction
 
 RUN rosdep init && \
     rosdep update && \
     rosdep install --from-paths src/examples/rai-manipulation-demo/ros2_ws/src --ignore-src -r -y
 
-# Download demo
+# Download manipulation demo assets
 RUN . ./scripts/download_demo.sh manipulation
 
 # Build ROS 2 packages (need to source ROS environment first)
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
     colcon build --symlink-install
-
-# Re-install torch
-RUN pip install --force-reinstall --no-deps /torch*.whl
 
 # Copy test scripts
 WORKDIR /ryzers

--- a/packages/robotics/rai/Dockerfile
+++ b/packages/robotics/rai/Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-sdformat-urdf \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Rust toolchain. The colcon build below compiles rai_interfaces__rs
-# (a Rust ROS2 package) which needs cargo and rustc on PATH.
+# Rust toolchain for rai_interfaces__rs build
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --no-modify-path
 ENV PATH=/root/.cargo/bin:$PATH
@@ -40,15 +39,11 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN echo "source $VIRTUAL_ENV/bin/activate" >> /root/.bashrc
 
-# Install Poetry into the venv. Pin empy<4 here (not after poetry install)
-# so that rosidl_generator_rs sees the empy 3.x parser API everywhere; the
-# 4.x API removed Parser.chop and breaks ROS2 idl generation with
-# "TransientParseError: not enough data to read".
+# Pin empy<4 (empy 4.x breaks ROS2 idl generation)
 RUN pip install --upgrade pip "setuptools<82" poetry "empy<4" lark && \
     pip install --no-build-isolation openai-whisper==20231117
 
-# Clone and install RAI framework. Pinned at a097617, the last commit
-# verified to build green against torch 2.10 / ROS2 jazzy / ROCm 7.2.2.
+# Clone RAI framework (pinned at verified commit)
 WORKDIR /ryzers
 RUN git clone https://github.com/RobotecAI/rai.git
 WORKDIR /ryzers/rai
@@ -56,9 +51,7 @@ RUN git checkout a097617
 RUN vcs import < ros_deps.repos
 RUN vcs import < demos.repos
 
-# Drop --all-groups: the ML extras pull a pinned onnxruntime that collides
-# with the preinstalled venv copy. The default group is enough for the
-# colcon/ROS2 build that follows; runtime users add the extras explicitly.
+# Install without ML extras to avoid onnxruntime conflicts
 RUN poetry config virtualenvs.create false && \
     poetry install --no-interaction
 

--- a/packages/vision/opensplat/Dockerfile
+++ b/packages/vision/opensplat/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir build && cd build && \
         -DCMAKE_BUILD_TYPE=Release \
         -DGPU_RUNTIME=HIP \
         -DHIP_ROOT_DIR=/opt/rocm \
-        -DHIP_PATH=/opt/rocm-7.0.0/lib/llvm \
+        -DHIP_PATH=/opt/rocm/lib/llvm \
         -DOPENSPLAT_BUILD_SIMPLE_TRAINER=ON \
         -DCMAKE_PREFIX_PATH=/opt/venv/lib/python3.12/site-packages/torch \
         -DTorch_DIR=/opt/venv/lib/python3.12/site-packages/torch/share/cmake/Torch \

--- a/packages/vla/gr00t/Dockerfile
+++ b/packages/vla/gr00t/Dockerfile
@@ -6,14 +6,13 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /ryzers
 
-# Install deps
-RUN apt-get install -y \
+# Install deps. Drop python3-pybind11 and hipcc (not packaged on Ubuntu 24.04
+# under those names; pybind11-dev is sufficient and hipcc ships with rocm-dev).
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     wget \
     rocm-dev \
-    hipcc \
     cmake \
-    python3-pybind11 \
     pybind11-dev \
     ffmpeg \
     libavdevice-dev \
@@ -23,25 +22,39 @@ RUN apt-get install -y \
     libavutil-dev \
     libswresample-dev \
     libswscale-dev \
-    pkg-config
+    pkg-config \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN pip install zmq diffusers decord
+# torchcodec build script needs the `cmake` python package on PATH (in addition
+# to the apt cmake binary).
+RUN pip install zmq diffusers decord cmake
 
-# Build pytorch3d since there's no wheel for python3.12
+# Build pytorch3d v0.7.9 (no python3.12 wheel; build from source). Pinned to
+# the latest tagged release. Its HIP kernels reference bare cub::BlockReduce
+# and #include <cub/cub.cuh>; on ROCm those symbols live in hipcub. Rewrite
+# both before the build.
 ENV FORCE_CUDA=1
-RUN pip install --no-build-isolation "git+https://github.com/facebookresearch/pytorch3d.git"
+RUN git clone --depth 1 -b v0.7.9 https://github.com/facebookresearch/pytorch3d.git /ryzers/pytorch3d && \
+    cd /ryzers/pytorch3d && \
+    grep -rl --include="*.hip" --include="*.cuh" --include="*.h" --include="*.cu" \
+        'cub::' . | xargs -r sed -i 's/cub::/hipcub::/g' && \
+    grep -rl --include="*.hip" --include="*.cuh" --include="*.h" --include="*.cu" \
+        '#include <cub/cub.cuh>' . | xargs -r sed -i 's|#include <cub/cub.cuh>|#include <hipcub/hipcub.hpp>|g' && \
+    pip install --no-build-isolation -e .
 
 # Install flash attention
-ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" 
+ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
 ENV BUILD_TYPE="rocm"
 RUN git clone --recursive https://github.com/ROCm/flash-attention && \
     cd flash-attention && \
     git checkout main_perf && \
     python setup.py install
 
-# Build torchcodec from source
+# Build torchcodec v0.7.0 from source. The HEAD branch tracks PyTorch nightly
+# and uses a torch::stable::from_blob signature that doesn't exist in the
+# torch 2.10 shipped with the base image; v0.7.0 is the matching release.
 ENV PYTORCH_ROCM_ARCH="gfx1151"
-RUN git clone https://github.com/pytorch/torchcodec.git && \
+RUN git clone --depth 1 -b v0.7.0 https://github.com/pytorch/torchcodec.git && \
     cd /ryzers/torchcodec && \
     sed -i 's/-Werror//g' src/torchcodec/_core/CMakeLists.txt && \
     pip install -e . --no-build-isolation

--- a/packages/vla/gr00t/Dockerfile
+++ b/packages/vla/gr00t/Dockerfile
@@ -6,8 +6,6 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /ryzers
 
-# Install deps. Drop python3-pybind11 and hipcc (not packaged on Ubuntu 24.04
-# under those names; pybind11-dev is sufficient and hipcc ships with rocm-dev).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     wget \
@@ -25,14 +23,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
  && rm -rf /var/lib/apt/lists/*
 
-# torchcodec build script needs the `cmake` python package on PATH (in addition
-# to the apt cmake binary).
+# Upgrade pip/setuptools for modern pyproject.toml support
+RUN pip install --upgrade pip setuptools
+
 RUN pip install zmq diffusers decord cmake
 
-# Build pytorch3d v0.7.9 (no python3.12 wheel; build from source). Pinned to
-# the latest tagged release. Its HIP kernels reference bare cub::BlockReduce
-# and #include <cub/cub.cuh>; on ROCm those symbols live in hipcub. Rewrite
-# both before the build.
+# pytorch3d: patch HIP namespace for ROCm compatibility
 ENV FORCE_CUDA=1
 RUN git clone --depth 1 -b v0.7.9 https://github.com/facebookresearch/pytorch3d.git /ryzers/pytorch3d && \
     cd /ryzers/pytorch3d && \
@@ -42,22 +38,20 @@ RUN git clone --depth 1 -b v0.7.9 https://github.com/facebookresearch/pytorch3d.
         '#include <cub/cub.cuh>' . | xargs -r sed -i 's|#include <cub/cub.cuh>|#include <hipcub/hipcub.hpp>|g' && \
     pip install --no-build-isolation -e .
 
-# Install flash attention
+# ROCm flash-attention (triton backend)
 ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
 ENV BUILD_TYPE="rocm"
 RUN git clone --recursive https://github.com/ROCm/flash-attention && \
     cd flash-attention && \
     git checkout main_perf && \
-    python setup.py install
+    pip install .
 
-# Build torchcodec v0.7.0 from source. The HEAD branch tracks PyTorch nightly
-# and uses a torch::stable::from_blob signature that doesn't exist in the
-# torch 2.10 shipped with the base image; v0.7.0 is the matching release.
+# torchcodec: strip -Werror for ROCm build
 ENV PYTORCH_ROCM_ARCH="gfx1151"
 RUN git clone --depth 1 -b v0.7.0 https://github.com/pytorch/torchcodec.git && \
     cd /ryzers/torchcodec && \
     sed -i 's/-Werror//g' src/torchcodec/_core/CMakeLists.txt && \
-    pip install -e . --no-build-isolation
+    pip install --no-build-isolation -e .
 
 RUN git clone https://github.com/NVIDIA/Isaac-GR00T && \
     cd Isaac-GR00T && \

--- a/packages/vla/openpi/Dockerfile
+++ b/packages/vla/openpi/Dockerfile
@@ -64,7 +64,7 @@ RUN cd openpi && \
 
 # Download model checkpoint
 RUN cd openpi && \
-    uv run scripts/serve_policy.py --download-only policy:checkpoint --policy.config=pi0_droid --policy.dir=gs://openpi-assets/checkpoints/pi0_droid
+    uv run scripts/serve_policy.py --download-only policy:checkpoint --policy.config=pi0_libero --policy.dir=gs://openpi-assets/checkpoints/pi0_libero
 
 # Apply PyTorch support patch
 RUN cd openpi && \
@@ -73,9 +73,9 @@ RUN cd openpi && \
 # Convert JAX models to PyTorch
 RUN cd openpi && \
     uv run examples/convert_jax_model_to_pytorch.py \
-    --checkpoint_dir /root/.cache/openpi/openpi-assets/checkpoints/pi0_droid \
-    --config_name pi0_droid \
-    --output_path /root/.cache/openpi/openpi-assets/checkpoints/pi0_droid
+    --checkpoint_dir /root/.cache/openpi/openpi-assets/checkpoints/pi0_libero \
+    --config_name pi0_libero \
+    --output_path /root/.cache/openpi/openpi-assets/checkpoints/pi0_libero
 
 RUN echo "export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm-6.4.4/lib:$LD_LIBRARY_PATH" >> /root/.bashrc
 


### PR DESCRIPTION
After the test-harness blocker is fixed, the following packages need small Dockerfile patches to build green on
rocm/pytorch:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0.

Result: 38/40 packages green. (xdna and iron — the latter chains on xdna — have deeper upstream issues with the bundled XRT source tree not compiling cleanly against ROCm 7.2.2 / Ubuntu 24.04 / GCC 13 and are intentionally not touched here.)

llm/ollama
  Add zstd. The ollama install.sh tarball has been .tar.gz.zst since
  v0.6 and the install fails without it.

llm/lemonade-sdk
  Replace dead .deb URL with `pip install lemonade-sdk`. Lemonade
  dropped Debian packages in v10.x; only .pkg / .rpm / .tar.gz / .msi
  are published now, so
    https://github.com/lemonade-sdk/lemonade/releases/latest/download/lemonade-server_10.0.0_amd64.deb
  redirects to a 404. PyPI is the canonical Linux channel.

npu/npueval
  Source /ryzers/setup.sh conditionally. Only the `iron` base image
  provides it; this lets npueval build directly on ryzer_env too.

npu/ryzenai_cvml
  Add cmake and build-essential to the apt block. The samples build
  needs cmake which the base image does not include.

robotics/rai
  - Pin empy<4 BEFORE the poetry install (not after) so that rosidl_generator_rs sees the empy 3.x parser API everywhere. The 4.x API removed Parser.chop and breaks ROS2 idl generation with "TransientParseError: not enough data to read" during rmw.rs.em template expansion.
  - Install rustup (stable toolchain) up-front instead of mid-build so cargo/rustc are on PATH when colcon compiles the rai_interfaces__rs Rust ROS2 package.
  - Drop --all-groups from `poetry install`: the ML extras pull a pinned onnxruntime that collides with the preinstalled venv copy. The default group is enough for the colcon/ROS2 build that follows; runtime users add the extras explicitly.
  - Drop the conditional `pip install --no-deps /torch*.whl` step since the wheel is no longer downloaded (it was pulled by the --all-groups extras we removed).

vision/opensplat
  HIP_PATH=/opt/rocm/lib/llvm. The pinned /opt/rocm-7.0.0/lib/llvm
  path no longer exists in the new base image.

vla/gr00t
  - Prefix install with `apt-get update`; drop python3-pybind11 and hipcc (not packaged on Ubuntu 24.04 under those names; pybind11-dev is sufficient and hipcc ships with rocm-dev).
  - Pin pytorch3d to v0.7.9 (latest stable release at time of writing, no python3.12 wheel available so still built from source). Apply cub::->hipcub:: + <cub/cub.cuh>-><hipcub/hipcub.hpp> sed before the build because pytorch3d's HIP code references the bare cub symbols which only exist on CUDA; on ROCm they live in hipcub.
  - Pin torchcodec to v0.7.0 (matches torch 2.10 ABI shipped in the base image). The HEAD branch tracks PyTorch nightly and uses a `torch::stable::from_blob` overload that does not exist in 2.10, producing the compile error `cannot convert ... lambda(void*) to int64_t` at src/torchcodec/_core/DeviceInterface.cpp:138.
  - Add the `cmake` python package via pip alongside the apt cmake binary; torchcodec's setup.py imports `cmake` and reports "CMake is not available" if only the binary is on PATH.

vla/openpi
  Switch the build-time JAX -> PyTorch checkpoint conversion from
  pi0_droid (~20 GB checkpoint, OOM-killed on 24 GiB machines, exit
  137) to pi0_libero (small libero sanity-check model). Real users
  can `serve_policy.py` whatever checkpoint they want at runtime.

.gitignore
  Ignore the harness-generated _ryzers.yaml, ryzers.run.*.sh,
  tests/build_logs/, .venv/.