### PR TITLE
packages: ROCm 7.2.2 fixes + per-package conda prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ dist/
 
 # docs
 docs/_build/
+ryzers/_ryzers.yaml
+ryzers.run.*.sh
+tests/build_logs/
+.venv/

--- a/packages/init/ryzer_env/Dockerfile
+++ b/packages/init/ryzer_env/Dockerfile
@@ -6,54 +6,16 @@ FROM ${BASE_IMAGE}
 
 SHELL ["/bin/bash", "-lc"]
 
-
 RUN getent group render || groupadd render
 RUN getent group video || groupadd video
 RUN getent group kvm || groupadd kvm
-
 
 RUN usermod -aG render root
 RUN usermod -aG video root
 RUN usermod -aG kvm root
 
-#################################
-# Install ROCm Using ROCm Docker
-#################################
-
-
-
-
-#####################################
-# Install ROCm Using TheRock Steps
-#####################################
-
-# add dependencies
-# RUN apt-get update && \
-#     apt-get install -y \
-# 	python3 \
-#     	python3.12 \
-# 	python3.12-dev \
-# 	python3.12-venv \
-# 	python3-pip
-
-# RUN python3 -m venv /ryzers/venv_ryzers
-# ENV PATH="/ryzers/venv_ryzers/bin:$PATH"
-
-# RUN  python3 -m pip install \
-#   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-#   rocm[libraries,devel]
-
-# # install torch
-# RUN  python3 -m pip install \
-#   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-#   torch torchaudio torchvision
-
-
-
-# add a sign-of-life test
 WORKDIR /ryzers
 COPY test.sh /ryzers/test_init.sh
 RUN chmod +x /ryzers/test_init.sh
 
-# Command to run a test
-CMD /ryzers/test_init.sh  
+CMD /ryzers/test_init.sh

--- a/packages/llm/lemonade-sdk/Dockerfile
+++ b/packages/llm/lemonade-sdk/Dockerfile
@@ -12,13 +12,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         git
 
-# Install lemonade-server via official Debian package
-RUN wget -q -O /tmp/lemonade-server.deb \
-        https://github.com/lemonade-sdk/lemonade/releases/latest/download/lemonade-server_10.0.0_amd64.deb \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/lemonade-server.deb \
-    && rm -f /tmp/lemonade-server.deb \
-    && rm -rf /var/lib/apt/lists/*
+# Install lemonade-sdk from PyPI. The Debian release was discontinued in v10.x
+# upstream (only .pkg / .rpm / .tar.gz / .msi are published now), so the
+# previous releases/latest/download/lemonade-server_10.0.0_amd64.deb URL
+# 404s. PyPI is the canonical Linux distribution channel.
+RUN python3 -m pip install --no-cache-dir --break-system-packages "lemonade-sdk"
 
 # Copy test script
 WORKDIR /ryzers

--- a/packages/llm/ollama/Dockerfile
+++ b/packages/llm/ollama/Dockerfile
@@ -4,10 +4,14 @@
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-# add dependencies
+# add dependencies. zstd is required because the ollama install.sh tarball is
+# .tar.gz.zst since v0.6.
 RUN apt-get update && \
-    apt-get install -y \
-	curl
+    apt-get install -y --no-install-recommends \
+	curl \
+	ca-certificates \
+	zstd && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://ollama.com/install.sh | sh
 RUN python3 -m pip install ollama
@@ -21,4 +25,5 @@ RUN chmod +x /ryzers/test_ollama.sh
 EXPOSE 11434
 
 # Run ollama prompt/reply test
+
 CMD /ryzers/test_ollama.sh

--- a/packages/npu/iron/Dockerfile
+++ b/packages/npu/iron/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone --recursive https://github.com/xilinx/mlir-aie.git /ryzers/mlir-ai
     git submodule update --recursive
 
 # Comment out NPU check - we don't have access to /dev/accel during docker build
-RUN sed -i '31s/^/#/' /ryzers/mlir-aie/utils/quick_setup.sh
+RUN sed -i '31s/"/#/' /ryzers/mlir-aie/utils/quick_setup.sh
 
 # Lock down wheels
 RUN sed -i '61s|.*|pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2025051904+c105c0b-cp312-cp312-manylinux_2_35_x86_64.whl|' /ryzers/mlir-aie/utils/quick_setup.sh

--- a/packages/npu/npueval/Dockerfile
+++ b/packages/npu/npueval/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE=iron
 FROM ${BASE_IMAGE}
+# Use system python (ROCm PyTorch), not conda
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
@@ -7,9 +9,13 @@ COPY test.sh /ryzers/
 
 # Install NPUEval
 RUN git clone https://github.com/amdresearch/npueval
-RUN source /ryzers/setup.sh && \
-    cd /ryzers/npueval && \
-    python3 -m pip install -e .
+# Source /ryzers/setup.sh only if it's present. The iron base provides it but
+# we want this Dockerfile to also work when built directly on ryzer_env.
+RUN if [ -f /ryzers/setup.sh ]; then \
+        bash -lc "source /ryzers/setup.sh && cd /ryzers/npueval && python3 -m pip install -e ."; \
+    else \
+        cd /ryzers/npueval && python3 -m pip install -e .; \
+    fi
 
 # Cleanup
 ENV SHELL=/bin/bash

--- a/packages/npu/ryzenai_cvml/Dockerfile
+++ b/packages/npu/ryzenai_cvml/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y \
 	libboost-filesystem1.74.0 \
 	vulkan-tools \
 	mesa-vulkan-drivers \
-	git-lfs
+	git-lfs \
+	cmake \
+	build-essential
 
 RUN apt install -y vulkan-tools mesa-vulkan-drivers
 RUN add-apt-repository ppa:deadsnakes/ppa && \

--- a/packages/robotics/act/Dockerfile
+++ b/packages/robotics/act/Dockerfile
@@ -3,10 +3,10 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
-# Install deps
 RUN apt-get update && apt-get install -y git \
 	vim \
 	wget \
@@ -23,8 +23,10 @@ RUN pip install matplotlib && \
 	pip install dm_control && \
 	pip install pyquaternion
 
-
 COPY test.sh /ryzers/
 RUN chmod +x /ryzers/
+
+# Validate ROCm torch not overridden
+RUN /ryzers/test_init.sh
 
 CMD ["/bin/bash", "-c", "/ryzers/test.sh"]

--- a/packages/robotics/lerobot/Dockerfile
+++ b/packages/robotics/lerobot/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/robotics/rai/Dockerfile
+++ b/packages/robotics/rai/Dockerfile
@@ -1,19 +1,15 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ros
 FROM ${BASE_IMAGE}
-
-# Avoid interactive prompts
+ARG ROS_DISTRO=jazzy
+ENV ROS_DISTRO=${ROS_DISTRO}
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install additional dependencies for RAI
-RUN apt-get update && apt-get install -y \
-    git \
-    unzip \
-    ffmpeg \
-    libportaudio2 \
-    python3-venv \
+# ROS2 dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git unzip ffmpeg libportaudio2 python3-venv \
     ros-${ROS_DISTRO}-rai-interfaces \
     ros-${ROS_DISTRO}-moveit \
     ros-${ROS_DISTRO}-gazebo-msgs \
@@ -23,55 +19,48 @@ RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-sdformat-urdf \
  && rm -rf /var/lib/apt/lists/*
 
-# Configure linker to find sdformat vendor libraries
+# Rust toolchain (needed by rai_interfaces__rs ROS2 package)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --no-modify-path
+ENV PATH=/root/.cargo/bin:$PATH
+
 RUN echo "/opt/ros/${ROS_DISTRO}/opt/sdformat_vendor/lib" > /etc/ld.so.conf.d/ros-sdformat.conf && \
     ldconfig
 
-# Use existing virtual env from base image
+# Activate base image venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN echo "source $VIRTUAL_ENV/bin/activate" >> /root/.bashrc
 
-# Install Poetry into the venv
-RUN pip install --upgrade pip "setuptools<82" poetry empy lark && \
+# Pin empy<4 (required by rosidl_generator_rs)
+RUN pip install --upgrade pip "setuptools<82" poetry "empy<4" lark && \
     pip install --no-build-isolation openai-whisper==20231117
 
-# Clone and install RAI framework
+# RAI framework (pinned commit)
 WORKDIR /ryzers
 RUN git clone https://github.com/RobotecAI/rai.git
-
 WORKDIR /ryzers/rai
-RUN git checkout a097617 # pin working commit
+RUN git checkout a097617
 RUN vcs import < ros_deps.repos
 RUN vcs import < demos.repos
 
 RUN poetry config virtualenvs.create false && \
-    poetry install --all-groups
+    poetry install --no-interaction
 
 RUN rosdep init && \
     rosdep update && \
     rosdep install --from-paths src/examples/rai-manipulation-demo/ros2_ws/src --ignore-src -r -y
 
-# Download demo
 RUN . ./scripts/download_demo.sh manipulation
 
-# Build ROS 2 packages (need to source ROS environment first)
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
     colcon build --symlink-install
 
-# Re-install torch
-RUN pip install --force-reinstall --no-deps /torch*.whl
-
-# Copy test scripts
 WORKDIR /ryzers
 COPY test.sh /ryzers/test_rai.sh
 RUN chmod +x /ryzers/test_rai.sh
-
 COPY manipulation_demo.sh /ryzers/manipulation_demo.sh
 RUN chmod +x /ryzers/manipulation_demo.sh
 
-# Expose common ports (Streamlit frontend, LangFuse)
 EXPOSE 8501
-
-# Default command runs test
 CMD /ryzers/test_rai.sh

--- a/packages/robotics/rai/ryzers.yaml
+++ b/packages/robotics/rai/ryzers.yaml
@@ -1,0 +1,1 @@
+init_image: ros

--- a/packages/vision/dinov3/Dockerfile
+++ b/packages/vision/dinov3/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vision/mobilesam/Dockerfile
+++ b/packages/vision/mobilesam/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
@@ -10,7 +11,7 @@ RUN apt-get update
 RUN apt install -y python3-pip wget
 
 # Clone the repository and install segment-anything
-RUN git clone https://github.com/ChaoningZhang/MobileSAM.git && \
+RUN git clone https://github.com/chaoningzhang/MobileSAM.git && \
     cd MobileSAM && \
     pip3 install -e . && \
     pip3 install timm gradio matplotlib opencv-python
@@ -22,4 +23,3 @@ COPY test.sh /ryzers/test_mobilesam.sh
 RUN chmod +x /ryzers/test_mobilesam.sh
 
 CMD /ryzers/test_mobilesam.sh
-

--- a/packages/vision/ncnn/Dockerfile
+++ b/packages/vision/ncnn/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vision/opencv/Dockerfile
+++ b/packages/vision/opencv/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 # Set the OpenCV version as an argument (set in config.yaml)
 ARG OPENCV_VERSION

--- a/packages/vision/opensplat/Dockerfile
+++ b/packages/vision/opensplat/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir build && cd build && \
         -DCMAKE_BUILD_TYPE=Release \
         -DGPU_RUNTIME=HIP \
         -DHIP_ROOT_DIR=/opt/rocm \
-        -DHIP_PATH=/opt/rocm-7.0.0/lib/llvm \
+        -DHIP_PATH=/opt/rocm/lib/llvm \
         -DOPENSPLAT_BUILD_SIMPLE_TRAINER=ON \
         -DCMAKE_PREFIX_PATH=/opt/venv/lib/python3.12/site-packages/torch \
         -DTorch_DIR=/opt/venv/lib/python3.12/site-packages/torch/share/cmake/Torch \

--- a/packages/vision/sam/Dockerfile
+++ b/packages/vision/sam/Dockerfile
@@ -3,6 +3,8 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+# Use system python (ROCm PyTorch), not conda
+SHELL ["/bin/bash", "-c"]
 
 # Set the environment variable required for HIP kernel compilation
 ENV HSA_OVERRIDE_GFX_VERSION=11.0.0
@@ -14,8 +16,8 @@ RUN git clone https://github.com/facebookresearch/segment-anything.git && \
     cd segment-anything && \
     git checkout dca509fe793f601edb92606367a655c15ac00fdf && \
     sed -i 's|, "onnx.*"||' setup.py && \
-    sed -i 's|, "torchvision[^"]*"||g' setup.py && \
-    sed -i 's|, "torch[^"]*"||g' setup.py && \
+    sed -i 's|, "torchvision[""]*"||g' setup.py && \
+    sed -i 's|, "torch[""]*"||g' setup.py && \
     pip3 install .
 
 RUN apt-get install -y libjpeg-dev python3-dev python3-pip 

--- a/packages/vision/sam3/Dockerfile
+++ b/packages/vision/sam3/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
@@ -23,6 +24,7 @@ RUN mkdir -p /ryzers/data/ && \
 RUN pip install -U matplotlib nicegui huggingface_hub
 
 # Install transformers package from github
+SHELL ["/bin/bash", "-c"]
 RUN git clone https://github.com/huggingface/transformers.git /ryzers/transformers && \
     cd /ryzers/transformers && \
     pip install -e '.[torch]'

--- a/packages/vision/ultralytics/Dockerfile
+++ b/packages/vision/ultralytics/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers 
 

--- a/packages/vla/cogact/Dockerfile
+++ b/packages/vla/cogact/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
@@ -13,14 +14,14 @@ RUN apt-get update && apt-get install -y git vim wget
 # we patch and install separately to preserve rocm-native install
 RUN git clone https://github.com/openvla/openvla && \
     cd openvla && \
-    sed -i -E '/^\s*dependencies\s*=\s*\[/,/^\s*\]/{ /^\s*"(torch|torchvision|torchaudio)[^"]*",?\s*(#.*)?$/d }' pyproject.toml && \
+    sed -i -E '/"\s*dependencies\s*=\s*\[/,/"\s*\]/{ /"\s*"(torch|torchvision|torchaudio)[""]*",?\s*(#.*)?$/d }' pyproject.toml && \
     pip install -e .
 
 # Installed patched CogACT
 RUN git clone https://github.com/microsoft/CogACT && \
     cd CogACT && \
-    sed -i -E '/^\s*dependencies\s*=\s*\[/,/^\s*\]/{ /^\s*"(torch|torchvision|torchaudio)[^"]*",?\s*(#.*)?$/d }' pyproject.toml && \
-    sed -i -E 's/"openvla @[^"]*"/"openvla"/' pyproject.toml && \
+    sed -i -E '/"\s*dependencies\s*=\s*\[/,/"\s*\]/{ /"\s*"(torch|torchvision|torchaudio)[""]*",?\s*(#.*)?$/d }' pyproject.toml && \
+    sed -i -E 's/"openvla @[""]*"/"openvla"/' pyproject.toml && \
     pip install -e .
 
 # Download test image

--- a/packages/vla/gr00t/Dockerfile
+++ b/packages/vla/gr00t/Dockerfile
@@ -3,45 +3,39 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
-# Install deps
-RUN apt-get install -y \
-    git \
-    wget \
-    rocm-dev \
-    hipcc \
-    cmake \
-    python3-pybind11 \
-    pybind11-dev \
-    ffmpeg \
-    libavdevice-dev \
-    libavfilter-dev \
-    libavformat-dev \
-    libavcodec-dev \
-    libavutil-dev \
-    libswresample-dev \
-    libswscale-dev \
-    pkg-config
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git wget rocm-dev cmake pybind11-dev ffmpeg \
+    libavdevice-dev libavfilter-dev libavformat-dev libavcodec-dev \
+    libavutil-dev libswresample-dev libswscale-dev pkg-config \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN pip install zmq diffusers decord
+RUN pip install zmq diffusers decord cmake
 
-# Build pytorch3d since there's no wheel for python3.12
+# Build pytorch3d from source (cub→hipcub rewrite for ROCm)
 ENV FORCE_CUDA=1
-RUN pip install --no-build-isolation "git+https://github.com/facebookresearch/pytorch3d.git"
+RUN git clone --depth 1 -b v0.7.9 https://github.com/facebookresearch/pytorch3d.git /ryzers/pytorch3d && \
+    cd /ryzers/pytorch3d && \
+    grep -rl --include="*.hip" --include="*.cuh" --include="*.h" --include="*.cu" \
+        'cub::' . | xargs -r sed -i 's/cub::/hipcub::/g' && \
+    grep -rl --include="*.hip" --include="*.cuh" --include="*.h" --include="*.cu" \
+        '#include <cub/cub.cuh>' . | xargs -r sed -i 's|#include <cub/cub.cuh>|#include <hipcub/hipcub.hpp>|g' && \
+    pip install --no-build-isolation -e .
 
-# Install flash attention
-ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" 
+# Flash attention (ROCm fork)
+ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
 ENV BUILD_TYPE="rocm"
 RUN git clone --recursive https://github.com/ROCm/flash-attention && \
     cd flash-attention && \
     git checkout main_perf && \
     python setup.py install
 
-# Build torchcodec from source
+# Build torchcodec v0.7.0 (matches torch 2.10 ABI)
 ENV PYTORCH_ROCM_ARCH="gfx1151"
-RUN git clone https://github.com/pytorch/torchcodec.git && \
+RUN git clone --depth 1 -b v0.7.0 https://github.com/pytorch/torchcodec.git && \
     cd /ryzers/torchcodec && \
     sed -i 's/-Werror//g' src/torchcodec/_core/CMakeLists.txt && \
     pip install -e . --no-build-isolation

--- a/packages/vla/molmoact/Dockerfile
+++ b/packages/vla/molmoact/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vla/openpi/Dockerfile
+++ b/packages/vla/openpi/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
@@ -58,13 +59,13 @@ RUN git clone https://github.com/Physical-Intelligence/openpi && \
 COPY openpi.patch /ryzers/openpi
 RUN cd openpi && \
     git apply ./openpi.patch && \
-    sed -i '/^override-dependencies = \[/ s/\]/, "av==13.1.0"]/' pyproject.toml && \
+    sed -i '/"override-dependencies = \[/ s/\]/, "av==13.1.0"]/' pyproject.toml && \
     GIT_LFS_SKIP_SMUDGE=1 uv sync && \
     GIT_LFS_SKIP_SMUDGE=1 uv pip install -e .
 
 # Download model checkpoint
 RUN cd openpi && \
-    uv run scripts/serve_policy.py --download-only policy:checkpoint --policy.config=pi0_droid --policy.dir=gs://openpi-assets/checkpoints/pi0_droid
+    uv run scripts/serve_policy.py --download-only policy:checkpoint --policy.config=pi0_libero --policy.dir=gs://openpi-assets/checkpoints/pi0_libero
 
 # Apply PyTorch support patch
 RUN cd openpi && \
@@ -73,9 +74,9 @@ RUN cd openpi && \
 # Convert JAX models to PyTorch
 RUN cd openpi && \
     uv run examples/convert_jax_model_to_pytorch.py \
-    --checkpoint_dir /root/.cache/openpi/openpi-assets/checkpoints/pi0_droid \
-    --config_name pi0_droid \
-    --output_path /root/.cache/openpi/openpi-assets/checkpoints/pi0_droid
+    --checkpoint_dir /root/.cache/openpi/openpi-assets/checkpoints/pi0_libero \
+    --config_name pi0_libero \
+    --output_path /root/.cache/openpi/openpi-assets/checkpoints/pi0_libero
 
 RUN echo "export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm-6.4.4/lib:$LD_LIBRARY_PATH" >> /root/.bashrc
 

--- a/packages/vla/openvla/Dockerfile
+++ b/packages/vla/openvla/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vla/smolvla/Dockerfile
+++ b/packages/vla/smolvla/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 
@@ -12,7 +13,7 @@ RUN apt-get update && apt-get install -y git vim wget
 RUN git clone https://github.com/huggingface/lerobot.git && \
 	cd lerobot && \
 	git checkout 5c87365cc160617c45dc5d1bbb3788de010271a7 && \
-	sed -i -E '/assert not torch\.isinf\((mean|std)\)\.any\(\)/ s/^([[:space:]]*)/\1#/' lerobot/common/policies/normalize.py
+	sed -i -E '/assert not torch\.isinf\((mean|std)\)\.any\(\)/ s/"([[:space:]]*)/\1#/' lerobot/common/policies/normalize.py
 
 RUN cd lerobot && \
 	pip install ".[smolvla]"

--- a/packages/vlm/gemma3/Dockerfile
+++ b/packages/vlm/gemma3/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vlm/lfm2vl/Dockerfile
+++ b/packages/vlm/lfm2vl/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vlm/phi4/Dockerfile
+++ b/packages/vlm/phi4/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 

--- a/packages/vlm/smolvlm/Dockerfile
+++ b/packages/vlm/smolvlm/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}  
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ryzers
 


### PR DESCRIPTION
Fixes 22 Dockerfiles for rocm/pytorch:rocm7.2.2_ubuntu24.04 base image.

ryzer_env: clean up commented-out code

ollama: add zstd for tar.gz.zst install tarball

lemonade-sdk: replace dead .deb URL with pip install

npueval: conditional /ryzers/setup.sh sourcing

ryzenai_cvml: add cmake and build-essential

opensplat: update HIP_PATH for ROCm 7.2

gr00t: pybind11-dev, pytorch3d cub->hipcub, torchcodec v0.7.0, cmake pip pkg

rai: pin empy<4, add rustup, drop --all-groups from poetry, ryzers.yaml init_image: ros

openpi: switch to pi0_libero checkpoint (avoids OOM)

mobilesam: fix git clone URL (chaoningzhang)

20 torch packages: SHELL [/bin/bash, -c] to prevent conda from overriding ROCm PyTorch