### PR TITLE
lemonade-sdk: install via PPA and update test/README for v10.x CLI

### DIFF
--- a/packages/llm/lemonade-sdk/Dockerfile
+++ b/packages/llm/lemonade-sdk/Dockerfile
@@ -12,19 +12,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         git
 
-# Install lemonade-server via official Debian package
-RUN wget -q -O /tmp/lemonade-server.deb \
-        https://github.com/lemonade-sdk/lemonade/releases/latest/download/lemonade-server_10.0.0_amd64.deb \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/lemonade-server.deb \
-    && rm -f /tmp/lemonade-server.deb \
-    && rm -rf /var/lib/apt/lists/*
+# Install lemonade-server from PPA.
+RUN add-apt-repository ppa:lemonade-team/stable
+RUN apt-get install -y lemonade-server
 
 # Copy test script
 WORKDIR /ryzers
 COPY test.sh /ryzers/test_lemonade-sdk.sh
 RUN chmod +x /ryzers/test_lemonade-sdk.sh
 
-EXPOSE 8000
+EXPOSE 13305
 
 CMD /ryzers/test_lemonade-sdk.sh

--- a/packages/llm/lemonade-sdk/README.md
+++ b/packages/llm/lemonade-sdk/README.md
@@ -1,6 +1,6 @@
 # Lemonade Server
 
-[Lemonade](https://lemonade-server.ai/) is a lightweight local AI server for running text, vision, image generation, and speech models on AMD hardware. It provides an OpenAI-compatible API at `http://localhost:8000/api/v1`, making it a drop-in backend for hundreds of apps that support the OpenAI protocol.
+[Lemonade](https://lemonade-server.ai/) is a lightweight local AI server for running text, vision, image generation, and speech models on AMD hardware. It provides an OpenAI-compatible API at `http://localhost:13305/api/v1`, making it a drop-in backend for hundreds of apps that support the OpenAI protocol.
 
 ### Build the Docker Image
 
@@ -13,9 +13,10 @@ ryzers run
 
 ```sh
 ryzers run bash
-lemonade-server list
-lemonade-server pull Qwen3-VL-8B-Instruct-GGUF
-lemonade-server serve --no-tray
+lemond &
+lemonade list
+lemonade pull Qwen3-VL-8B-Instruct-GGUF
+lemonade run Qwen3-VL-8B-Instruct-GGUF
 ```
 
 ### References

--- a/packages/llm/lemonade-sdk/config.yaml
+++ b/packages/llm/lemonade-sdk/config.yaml
@@ -4,7 +4,11 @@
 ### ryzers run options
 
 port_mappings:
-- "8000:8000"
+- "13305:13305"
 
 volume_mappings:
+# Hugging Face cache: backs the raw model weight files that lemonade pulls.
 - "$PWD/workspace/.cache/huggingface:/root/.cache/huggingface"
+# Lemonade cache: holds config.json, the model registry, and lemond's
+# downloaded-model index.
+- "$PWD/workspace/.cache/lemonade:/root/.cache/lemonade"

--- a/packages/llm/lemonade-sdk/test.sh
+++ b/packages/llm/lemonade-sdk/test.sh
@@ -8,23 +8,15 @@ echo "================================"
 
 # Use a small model for fast testing
 MODEL="Llama-3.2-1B-Instruct-GGUF"
+# v10.x default lemond port
+PORT=13305
 
-# Pull the model first
+# Start the lemond server in the background. Upstream v10.x split the CLI:
+# `lemond` runs the server
+# `lemonade` is the client CLI for everything else (pull/list/etc).
 echo ""
-echo "Pulling model $MODEL..."
-lemonade-server pull $MODEL || {
-  echo "Model already available or pull failed, continuing..."
-}
-
-# List available models
-echo ""
-echo "Available models:"
-lemonade-server list | head -20
-
-# Start lemonade-server in the background
-echo ""
-echo "Starting lemonade-server..."
-lemonade-server serve --no-tray > /tmp/lemonade.log 2>&1 &
+echo "Starting lemond on default port ${PORT}..."
+lemond > /tmp/lemonade.log 2>&1 &
 SERVER_PID=$!
 
 # Function to cleanup
@@ -33,7 +25,7 @@ cleanup() {
   echo "Stopping server..."
   kill $SERVER_PID 2>/dev/null
   sleep 1
-  pkill -9 lemonade-server 2>/dev/null
+  pkill -9 lemond 2>/dev/null
 }
 
 # Set trap to cleanup on exit
@@ -42,7 +34,7 @@ trap cleanup EXIT
 # Wait for server to be ready
 echo "Waiting for server to be ready..."
 for i in {1..60}; do
-  if curl -s http://localhost:8000/health > /dev/null 2>&1; then
+  if curl -s http://localhost:$PORT/api/v1/health > /dev/null 2>&1; then
     echo "Server is ready!"
     break
   fi
@@ -55,6 +47,18 @@ for i in {1..60}; do
   sleep 1
 done
 
+# Pull the model (the client talks to the server now that it's up)
+echo ""
+echo "Pulling model $MODEL..."
+lemonade pull $MODEL || {
+  echo "Pull failed; the server may still be able to lazy-load on first request."
+}
+
+# List available models
+echo ""
+echo "Available models (downloaded):"
+lemonade list --downloaded | head -20
+
 # Give it a moment to fully initialize
 sleep 2
 
@@ -64,7 +68,7 @@ echo "Testing completion API with model $MODEL..."
 echo "Prompt: 'Why is the sky blue? Answer in one sentence.'"
 echo ""
 
-RESPONSE=$(curl -s -X POST http://localhost:8000/api/v1/completions   -H "Content-Type: application/json"   -d '{
+RESPONSE=$(curl -s -X POST http://localhost:$PORT/api/v1/completions   -H "Content-Type: application/json"   -d '{
     "model": "'$MODEL'",
     "prompt": "Why is the sky blue?",
     "max_tokens": 100,


### PR DESCRIPTION
The upstream .deb release URL was retired so install via ppa:lemonade-team/stable. Lemonade v10.x splits the CLI into lemond (server) + lemonade (client) - test.sh and the README are updated accordingly.