### PR TITLE
npu: fix xdna/iron build on ROCm 7.2.2 base image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must use LF line endings; CRLF breaks the shebang
+# (e.g. `/usr/bin/env: 'bash\r'`) when COPYed into and executed in containers.
+*.sh text eol=lf

--- a/packages/npu/iron/Dockerfile
+++ b/packages/npu/iron/Dockerfile
@@ -1,14 +1,12 @@
 ARG BASE_IMAGE=xdna
 FROM ${BASE_IMAGE}
 
-# Where we'll install the build backend
 WORKDIR /ryzers
 COPY setup.sh /ryzers/setup.sh
 COPY entrypoint.sh /ryzers/entrypoint.sh
 
-# Set environment variable to suppress prompts in scripts
 ENV DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-l", "-c"]
+SHELL ["/bin/bash", "-c"]
 
 # IRON requires python venv
 RUN apt-get -y install python3.12-venv
@@ -33,7 +31,7 @@ RUN cd /ryzers/mlir-aie && \
     source /opt/xilinx/xrt/setup.sh && \
     source /ryzers/mlir-aie/utils/quick_setup.sh
 
-# Copy the new AIE pragma utils.h to mlir_aie/include/ so it's picked up when doing #include "aie_kernel_utils.h"
+# Make AIE kernel utils visible to mlir_aie include path
 RUN cp /ryzers/mlir-aie/aie_kernels/aie_kernel_utils.h /ryzers/mlir-aie/ironenv/lib/python3.12/site-packages/mlir_aie/include/
 
 # Install jupyter for notebooks
@@ -43,7 +41,6 @@ RUN source /ryzers/setup.sh && \
 # Cleanup
 ENV SHELL=/bin/bash
 
-# Make sure to source the setup script on docker start
 ENTRYPOINT ["/ryzers/entrypoint.sh"]
 
 COPY test.sh /ryzers/test.sh

--- a/packages/npu/iron/setup.sh
+++ b/packages/npu/iron/setup.sh
@@ -20,12 +20,8 @@ export PEANOWRAP2_FLAGS="-O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING
 export PEANOWRAP2P_FLAGS="-O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_INSTALL_DIR}/include "
 
 examine_output=$(xrt-smi examine)
-# Newer xrt-smi (XRT >= 2.20, shipped with ROCm 7.2.x) reports the part by
-# architecture and a generic device name (e.g. "RyzenAI-npu4", "aie2p") instead
-# of the marketing name, so match on the AIE architecture as the stable signal:
-#   aie2  -> Phoenix / Hawk Point  -> npu1
-#   aie2p -> Strix / Strix Halo / Krackan -> npu2
-# Check aie2p (npu2) first since "aie2p" also contains the substring "aie2".
+# Match on AIE architecture (aie2p=npu2, aie2=npu1); check aie2p first since
+# "aie2p" contains the substring "aie2".
 if echo "$examine_output" | grep -Eiq "Strix|Krackan|aie2p"; then
     export NPU=npu2
 elif echo "$examine_output" | grep -Eiq "Phoenix|Hawk|aie2"; then

--- a/packages/npu/iron/setup.sh
+++ b/packages/npu/iron/setup.sh
@@ -20,10 +20,16 @@ export PEANOWRAP2_FLAGS="-O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING
 export PEANOWRAP2P_FLAGS="-O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_INSTALL_DIR}/include "
 
 examine_output=$(xrt-smi examine)
-if echo $examine_output | grep -E "Phoenix|Hawk" > /dev/null; then
-    export NPU=npu1
-elif echo $examine_output | grep -E "Strix|Krackan" > /dev/null; then
+# Newer xrt-smi (XRT >= 2.20, shipped with ROCm 7.2.x) reports the part by
+# architecture and a generic device name (e.g. "RyzenAI-npu4", "aie2p") instead
+# of the marketing name, so match on the AIE architecture as the stable signal:
+#   aie2  -> Phoenix / Hawk Point  -> npu1
+#   aie2p -> Strix / Strix Halo / Krackan -> npu2
+# Check aie2p (npu2) first since "aie2p" also contains the substring "aie2".
+if echo "$examine_output" | grep -Eiq "Strix|Krackan|aie2p"; then
     export NPU=npu2
+elif echo "$examine_output" | grep -Eiq "Phoenix|Hawk|aie2"; then
+    export NPU=npu1
 else
     echo "No recognized NPU found"
 fi

--- a/packages/npu/ryzenai_cvml/config.yaml
+++ b/packages/npu/ryzenai_cvml/config.yaml
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 environment_variables:
-# ROCm 7.2.2 natively supports the Ryzen AI iGPUs, so HSA_OVERRIDE_GFX_VERSION
-# is no longer forced. On older ROCm or with detection issues, set it per
-# silicon (Phoenix=11.0.0, Strix Point=11.5.0, Strix Halo=11.5.1, Krackan=11.5.2).
+# HSA_OVERRIDE_GFX_VERSION is not set: ROCm 7.2.2 detects the iGPUs natively.
+# On older ROCm, set it per silicon (see README "Supported silicon").
 - "RYZEN_AI_DIR=/ryzers/RyzenAI-SW/Ryzen-AI-CVML-Library"
 - "LD_LIBRARY_PATH=/ryzers/RyzenAI-SW/Ryzen-AI-CVML-Library/linux:/opt/xilinx/xrt/lib"
 

--- a/packages/npu/ryzenai_cvml/config.yaml
+++ b/packages/npu/ryzenai_cvml/config.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 environment_variables:
-- "HSA_OVERRIDE_GFX_VERSION=11.0.0"  # Required for HIP to write kernels
+# ROCm 7.2.2 natively supports the Ryzen AI iGPUs, so HSA_OVERRIDE_GFX_VERSION
+# is no longer forced. On older ROCm or with detection issues, set it per
+# silicon (Phoenix=11.0.0, Strix Point=11.5.0, Strix Halo=11.5.1, Krackan=11.5.2).
 - "RYZEN_AI_DIR=/ryzers/RyzenAI-SW/Ryzen-AI-CVML-Library"
 - "LD_LIBRARY_PATH=/ryzers/RyzenAI-SW/Ryzen-AI-CVML-Library/linux:/opt/xilinx/xrt/lib"
 

--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -25,11 +25,8 @@ RUN git clone https://github.com/amd/xdna-driver && \
     git checkout $DRIVER_VERSION && \
     git submodule update --init --recursive
 
-# Install build dependencies. amdxdna_deps.sh does not forward -docker to
-# xrtdeps.sh, so xrtdeps tries to install linux-headers-$(uname -r) (the HOST
-# kernel) and the whole apt batch fails, taking Boost and friends with it.
-# Call xrtdeps.sh directly with -docker so kernel headers are skipped, and
-# install jq (the only extra thing amdxdna_deps.sh adds) ourselves.
+# Install build dependencies (xrtdeps.sh -docker skips host kernel headers; jq
+# is the only extra package amdxdna_deps.sh would add)
 RUN cd /ryzers/xdna-driver && \
     apt-get update && \
     apt-get install -y jq && \
@@ -39,12 +36,8 @@ RUN cd /ryzers/xdna-driver && \
 RUN cd /ryzers/xdna-driver/xrt/build/ && \
     ./build.sh -npu -opt -noctest
 
-# Build the XDNA userspace (-release generates the xrt_plugin .deb). We pass
-# -nokmod so the in-container build does NOT try to compile the amdxdna kernel
-# module against linux-headers-$(uname -r): inside a container uname -r is the
-# HOST kernel, so the headers are unavailable on non-Ubuntu hosts (Arch,
-# Fedora, custom kernels) and the module cannot be loaded from a container
-# anyway. The kernel driver is installed/loaded on the host (see README).
+# Build the XDNA userspace (-release generates the xrt_plugin .deb); -nokmod
+# skips the kernel module, which is built and loaded on the host (see README)
 RUN cd /ryzers/xdna-driver/build && \
     ./build.sh -release -nokmod
 

--- a/packages/npu/xdna/Dockerfile
+++ b/packages/npu/xdna/Dockerfile
@@ -15,25 +15,38 @@ RUN apt-get update && apt-get install -y \
 	git \
 	curl \
 	bash \
-	wget
+	wget \
+	cmake \
+	ninja-build \
+	build-essential
 
 RUN git clone https://github.com/amd/xdna-driver && \
     cd xdna-driver && \
     git checkout $DRIVER_VERSION && \
     git submodule update --init --recursive
 
-# Install build dependencies
-RUN cd /ryzers/xdna-driver/tools && \
+# Install build dependencies. amdxdna_deps.sh does not forward -docker to
+# xrtdeps.sh, so xrtdeps tries to install linux-headers-$(uname -r) (the HOST
+# kernel) and the whole apt batch fails, taking Boost and friends with it.
+# Call xrtdeps.sh directly with -docker so kernel headers are skipped, and
+# install jq (the only extra thing amdxdna_deps.sh adds) ourselves.
+RUN cd /ryzers/xdna-driver && \
     apt-get update && \
-    ./amdxdna_deps.sh -docker
+    apt-get install -y jq && \
+    ./xrt/src/runtime_src/tools/scripts/xrtdeps.sh -docker
 
 # Build XRT
 RUN cd /ryzers/xdna-driver/xrt/build/ && \
     ./build.sh -npu -opt -noctest
 
-# Build XDNA driver (-release also generates the .deb package)
+# Build the XDNA userspace (-release generates the xrt_plugin .deb). We pass
+# -nokmod so the in-container build does NOT try to compile the amdxdna kernel
+# module against linux-headers-$(uname -r): inside a container uname -r is the
+# HOST kernel, so the headers are unavailable on non-Ubuntu hosts (Arch,
+# Fedora, custom kernels) and the module cannot be loaded from a container
+# anyway. The kernel driver is installed/loaded on the host (see README).
 RUN cd /ryzers/xdna-driver/build && \
-    ./build.sh -release
+    ./build.sh -release -nokmod
 
 # Finally, save and install the XRT/XDNA debian packages
 # these will also need to be installed on the host system

--- a/packages/npu/xdna/README.md
+++ b/packages/npu/xdna/README.md
@@ -48,4 +48,19 @@ Validation completed
 
 ---
 
+## Supported silicon
+
+What differs per platform is the NPU generation (used by IRON) and the iGPU ISA (relevant only if you must set `HSA_OVERRIDE_GFX_VERSION` on an older ROCm stack). On ROCm 7.2.2 the iGPUs are detected natively, so the override is left unset by default (see [config.yaml](config.yaml)).
+
+| Silicon | NPU gen | iGPU ISA | `HSA_OVERRIDE_GFX_VERSION` (only if needed) |
+| --- | --- | --- | --- |
+| Phoenix / Hawk Point | `npu1` | gfx1103 | `11.0.0` |
+| Strix Point | `npu2` | gfx1150 | `11.5.0` |
+| Strix Halo | `npu2` | gfx1151 | `11.5.1` |
+| Krackan Point | `npu2` | gfx1152 | `11.5.2` |
+
+The NPU generation is auto-detected from `xrt-smi examine` output by AIE architecture (`aie2` -> `npu1`, `aie2p` -> `npu2`; the marketing names `Phoenix`/`Hawk` and `Strix`/`Krackan` are also matched as a fallback), see [../iron/setup.sh](../iron/setup.sh). Newer `xrt-smi` (XRT >= 2.20, shipped with ROCm 7.2.x) reports a generic device name, so the architecture string is the stable signal. To force a GPU override on an older ROCm release, add it back to `config.yaml` (`environment_variables`) or pass it at runtime.
+
+---
+
 For further details, refer to the official [xdna-driver](https://github.com/amd/xdna-driver) repository.

--- a/packages/npu/xdna/config.yaml
+++ b/packages/npu/xdna/config.yaml
@@ -1,8 +1,11 @@
 # Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-environment_variables:
-- "HSA_OVERRIDE_GFX_VERSION=11.0.0"  # Required for HIP to write kernels
+# ROCm 7.2.2 natively supports the Ryzen AI iGPUs (gfx1150 Strix Point,
+# gfx1151 Strix Halo), so no HSA_OVERRIDE_GFX_VERSION is set by default.
+# If you are on an older ROCm stack or hit GPU detection issues, set it for
+# your silicon (see README "Supported silicon"): Phoenix=11.0.0,
+# Strix Point=11.5.0, Strix Halo=11.5.1, Krackan Point=11.5.2.
 
 docker_extra_run_flags:
     - "--device=/dev/accel/accel0:/dev/accel/accel0"

--- a/packages/npu/xdna/config.yaml
+++ b/packages/npu/xdna/config.yaml
@@ -1,11 +1,8 @@
 # Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# ROCm 7.2.2 natively supports the Ryzen AI iGPUs (gfx1150 Strix Point,
-# gfx1151 Strix Halo), so no HSA_OVERRIDE_GFX_VERSION is set by default.
-# If you are on an older ROCm stack or hit GPU detection issues, set it for
-# your silicon (see README "Supported silicon"): Phoenix=11.0.0,
-# Strix Point=11.5.0, Strix Halo=11.5.1, Krackan Point=11.5.2.
+# HSA_OVERRIDE_GFX_VERSION is not set: ROCm 7.2.2 detects the iGPUs natively.
+# On older ROCm, set it per silicon (see README "Supported silicon").
 
 docker_extra_run_flags:
     - "--device=/dev/accel/accel0:/dev/accel/accel0"


### PR DESCRIPTION
The base image bump to the ROCm 7.2.2 PyTorch image broke the xdna and iron builds. This adapts them to the new toolchain and XRT:

- xdna: install cmake/ninja-build/build-essential (no longer in base)
- xdna: call xrtdeps.sh -docker directly instead of amdxdna_deps.sh, which does not forward -docker and so fails installing host kernel headers
- xdna: build the userspace with -nokmod; the amdxdna kernel module is built and loaded on the host, not inside the container (host kernel != container)
- iron/setup.sh: detect the NPU by AIE architecture (aie2/aie2p) since newer xrt-smi reports a generic device name instead of the marketing name
- iron: drop the -l login-shell flag (consistency after conda removal)
- xdna/ryzenai_cvml: drop hardcoded HSA_OVERRIDE_GFX_VERSION; ROCm 7.2.2 detects the Ryzen AI iGPUs natively (documented per-silicon in the README)
- add .gitattributes to force LF on *.sh (CRLF breaks shebangs in containers)