### PR TITLE
Lemonade Fix for XDG Runtime Bug

### DIFF
--- a/packages/llm/lemonade-sdk/Dockerfile
+++ b/packages/llm/lemonade-sdk/Dockerfile
@@ -16,6 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN add-apt-repository ppa:lemonade-team/stable
 RUN apt-get install -y lemonade-server
 
+# Fix: create runtime dir and set XDG_RUNTIME_DIR for lemond
+# Workaround for lemonade-sdk#2083 (XDG_RUNTIME_DIR); revisit when a
+# release past v10.7.0 actually ships the fix from PR #2167.
+RUN mkdir -p /tmp/runtime-root && chmod 700 /tmp/runtime-root
+ENV XDG_RUNTIME_DIR=/tmp/runtime-root
+
 # Copy test script
 WORKDIR /ryzers
 COPY test.sh /ryzers/test_lemonade-sdk.sh


### PR DESCRIPTION
lemond failed at startup with 'Unable to resolve writable runtime directory from XDG_RUNTIME_DIR or RUNTIME_DIRECTORY (upstream bug lemonade-sdk/lemonade#2083)'. The fix (PR #2167) was supposed to ship in v10.7.0, but the installed v10.7.0 still hits the error, so set the runtime dir explicitly in the image as a workaround.