### PR TITLE
Llamacpp rocm7.14 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ These dockerfiles will also be pushed and actively maintained in their original 
 | VLA                     | [`OpenVLA`](packages/vla/openvla), [`SmolVLA`](packages/vla/smolvla), [`GR00T-N1.5`](packages/vla/gr00t), [`openpi`](packages/vla/openpi), [`CogACT`](packages/vla/cogact), [`MolmoAct`](packages/vla/molmoact), [`MolmoAct2`](packages/vla/molmoact2) |
 | Graphics                     | [`O3DE`](packages/graphics/o3de) |
 | Robotics                | [`ROS 2`](packages/ros/ros), [`Gazebo`](packages/ros/gazebo), [`LeRobot`](packages/robotics/lerobot), [`ACT`](packages/robotics/act), [`RAI`](packages/robotics/rai)    |
-| Simulation                |  [`Genesis`](packages/robotics/genesis), [`PyDrake`](packages/robotics/pydrake)  |
+| Simulation                |  [`Genesis`](packages/robotics/genesis), [`PyDrake`](packages/robotics/pydrake), [`CaP-X`](packages/robotics/capx)  |
 | Vision                  | [`OpenCV`](packages/vision/opencv), [`SAM`](packages/vision/sam), [`MobileSAM`](packages/vision/mobilesam), [`ncnn`](packages/vision/ncnn), [`DINOv3`](packages/vision/dinov3), [`SAM3`](packages/vision/sam3), [`Ultralytics`](packages/vision/ultralytics) |
 | Ryzen AI NPU                |  [`XDNA`](packages/npu/xdna), [`IRON`](packages/npu/iron), [`NPUEval`](packages/npu/npueval), [`Ryzen AI CVML`](packages/npu/ryzenai_cvml)  |
 | Adaptive SoCs           | [`PYNQ.remote`](packages/adaptive-socs/pynq-remote) |

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ These dockerfiles will also be pushed and actively maintained in their original 
 | VLM                     | [`Gemma3`](packages/vlm/gemma3), [`SmolVLM`](packages/vlm/smolvlm), [`Phi-4`](packages/vlm/phi4), [`LFM2-VL`](packages/vlm/lfm2vl) |
 | VLA                     | [`OpenVLA`](packages/vla/openvla), [`SmolVLA`](packages/vla/smolvla), [`GR00T-N1.5`](packages/vla/gr00t), [`openpi`](packages/vla/openpi), [`CogACT`](packages/vla/cogact), [`MolmoAct`](packages/vla/molmoact), [`MolmoAct2`](packages/vla/molmoact2) |
 | Graphics                     | [`O3DE`](packages/graphics/o3de) |
-| Robotics                | [`ROS 2`](packages/ros/ros), [`Gazebo`](packages/ros/gazebo), [`LeRobot`](packages/robotics/lerobot), [`ACT`](packages/robotics/act), [`RAI`](packages/robotics/rai)    |
-| Simulation                |  [`Genesis`](packages/robotics/genesis), [`PyDrake`](packages/robotics/pydrake), [`CaP-X`](packages/robotics/capx)  |
+| Robotics                | [`ROS 2`](packages/ros/ros), [`Gazebo`](packages/ros/gazebo), [`LeRobot`](packages/robotics/lerobot), [`ACT`](packages/robotics/act), [`RAI`](packages/robotics/rai), [`CaP-X`](packages/robotics/capx)    |
+| Simulation                |  [`Genesis`](packages/robotics/genesis), [`PyDrake`](packages/robotics/pydrake)  |
 | Vision                  | [`OpenCV`](packages/vision/opencv), [`SAM`](packages/vision/sam), [`MobileSAM`](packages/vision/mobilesam), [`ncnn`](packages/vision/ncnn), [`DINOv3`](packages/vision/dinov3), [`SAM3`](packages/vision/sam3), [`Ultralytics`](packages/vision/ultralytics) |
 | Ryzen AI NPU                |  [`XDNA`](packages/npu/xdna), [`IRON`](packages/npu/iron), [`NPUEval`](packages/npu/npueval), [`Ryzen AI CVML`](packages/npu/ryzenai_cvml)  |
 | Adaptive SoCs           | [`PYNQ.remote`](packages/adaptive-socs/pynq-remote) |

--- a/packages/llm/llamacpp/Dockerfile
+++ b/packages/llm/llamacpp/Dockerfile
@@ -27,12 +27,29 @@ RUN apt-get update \
 && apt update \
 && apt install -y vulkan-sdk
 
+# ROCm 7.14+ has no /opt/rocm; the HIP CMake package ships in rocm-sdk-devel.
+RUN /opt/venv/bin/pip install \
+      --index-url https://repo.amd.com/rocm/whl-multi-arch \
+      --extra-index-url https://pypi.org/simple \
+      "rocm[devel]==7.14.0" \
+ && /opt/venv/bin/rocm-sdk init
+
+ENV ROCM_PATH=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_devel
+
+# The wheel lib dirs are not on the loader path, so binaries fail on libhipblas.
+RUN printf '%s\n' \
+      /opt/venv/lib/python3.12/site-packages/_rocm_sdk_core/lib \
+      /opt/venv/lib/python3.12/site-packages/_rocm_sdk_libraries/lib \
+      /opt/venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib \
+      > /etc/ld.so.conf.d/rocm-wheels.conf && ldconfig
+
 # Clone and build LlamaCPP
 WORKDIR /ryzers
 RUN git clone https://github.com/ggml-org/llama.cpp.git llamacpp && \
     cd llamacpp && \
-    HIPCXX="$(hipconfig -l)/clang" HIP_PATH="$(hipconfig -R)" \
-    cmake -S . -B build -DLLAMA_CURL=ON -DGGML_VULKAN=1 -DGGML_HIP=ON -DAMDGPU_TARGETS=$GFXSTRING -DCMAKE_BUILD_TYPE=Release \
+    HIPCXX="$ROCM_PATH/lib/llvm/bin/clang++" HIP_PATH="$ROCM_PATH" \
+    cmake -S . -B build -DGGML_VULKAN=1 -DGGML_HIP=ON -DGPU_TARGETS=$GFXSTRING \
+    -DCMAKE_PREFIX_PATH="$(/opt/venv/bin/rocm-sdk path --cmake)" -DCMAKE_BUILD_TYPE=Release \
     && cmake --build build --config Release -- -j 16
 
 # Copy test script

--- a/packages/llm/llamacpp/config.yaml
+++ b/packages/llm/llamacpp/config.yaml
@@ -1,3 +1,4 @@
+init_image: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0"
 
 build_arguments:            
 - "GFXSTRING=gfx1151"               # llamacpp needs the amdgpu gfx string for build

--- a/packages/robotics/capx/Dockerfile
+++ b/packages/robotics/capx/Dockerfile
@@ -35,11 +35,11 @@ ARG CAPX_SIM=robosuite
 # versions in CaP-X's uv.lock. Override to track upstream.
 ARG CAPX_REF=53e9966d7a8e2fa7494676772bccc35280f5c0ed
 
+# MuJoCo headless rendering uses EGL/OpenGL rather than CUDA.
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PIP_BREAK_SYSTEM_PACKAGES=1 \
     CAPX_SIM=${CAPX_SIM} \
-    # MuJoCo headless rendering via EGL (OpenGL, not CUDA — works on AMD).
     MUJOCO_GL=egl \
     PYOPENGL_PLATFORM=egl
     # Strix Halo (Ryzen AI Max, gfx1151) is supported natively by ROCm 7.2,
@@ -74,8 +74,9 @@ import torch, torchvision
 print(f"torch=={torch.__version__.split('+')[0]}")
 print(f"torchvision=={torchvision.__version__.split('+')[0]}")
 PY
-# Match CaP-X's uv override-dependencies (pyproject.toml [tool.uv]):
-#   numpy==1.26.4, PyOpenGL==3.1.6, opencv-python-headless<4.13, jax/jaxlib<0.4.30.
+# Match CaP-X's uv override-dependencies and the Python 3.12 Robosuite
+# resolution in its lockfile. In particular, Robosuite 1.5.1 still calls the
+# pre-3.10 mj_fullM API, so allowing the current MuJoCo release breaks startup.
 # FIX: CaP-X also pins PyOpenGL-accelerate==3.1.6, but that version has no cp312
 # wheel and fails to compile on the base image's Python 3.12. -accelerate is an
 # optional perf add-on (not required), so we omit the pin and only constrain
@@ -86,6 +87,10 @@ RUN printf '%s\n' \
         'opencv-python-headless<4.13' \
         'jax==0.4.29' \
         'jaxlib==0.4.29' \
+        'mujoco==3.5.0' \
+        'mink==1.1.0' \
+        'networkx==3.6.1' \
+        'pyglet==2.1.13' \
     >> /ryzers/constraints.txt && cat /ryzers/constraints.txt
 
 # ---------------------------------------------------------------------------
@@ -117,9 +122,16 @@ RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         requests tqdm h5py einops decord pycocotools pyyaml omegaconf \
         open3d "robot_descriptions>=1.16.0" "yourdfpy>=0.0.56" "viser>=0.2.0" \
         "trimesh>=4.4.0" msgpack_numpy "ray==2.48.0" "mediapy>=1.2.5" \
-        uvicorn fastapi "transformers<5.0" openai pyrender \
+        uvicorn fastapi "transformers<5.0" openai \
         "opencv-python-headless<4.13" "pillow>=10" cloudpickle \
-        "setuptools<81"
+        "setuptools<81" \
+        "mujoco==3.5.0" "mink==1.1.0" "networkx==3.6.1" "pyglet==2.1.13" \
+        "pyliblzfse==0.4.1" freetype-py six
+
+# CaP-X overrides pyrender's stale PyOpenGL==3.1.0 metadata to PyOpenGL 3.1.6.
+# pip cannot express uv's override directly, so install the exact locked
+# pyrender after all of its runtime dependencies are present.
+RUN pip install --no-cache-dir --no-deps "pyrender==0.1.45"
 
 # ---------------------------------------------------------------------------
 # PyRoKi (JAX-based IK / trajopt — the DEFAULT motion layer; replaces cuRobo for

--- a/packages/robotics/capx/Dockerfile
+++ b/packages/robotics/capx/Dockerfile
@@ -9,20 +9,6 @@
 #   - LIBERO-PRO (robosuite 1.4.x)
 # Because the two pin conflicting robosuite versions, pick ONE per image with:
 #   --build-arg CAPX_SIM=robosuite   (default)   or   CAPX_SIM=libero
-#
-# The Ryzers default base (rocm/pytorch:...py3.12_pytorch_release_2.10.0) already
-# ships a ROCm-built torch/torchvision; we DO NOT reinstall torch so the ROCm
-# build is preserved. GPU work (SAM3, Contact-GraspNet) runs on ROCm torch;
-# MuJoCo renders via EGL on the AMD GPU; PyRoKi IK runs on CPU jax (matching
-# CaP-X upstream, whose lockfile pins plain CPU jax 0.4.29 — no GPU jax plugin).
-#
-# NOT included (out of scope for the eval image):
-#   - cuRobo  (hand-written CUDA/NVRTC kernels, no ROCm fork; gated off in the
-#             default Robosuite/LIBERO configs anyway — PyRoKi is the default
-#             motion layer)
-#   - verl / vllm / flash-attn  (CaP-RL TRAINING path, not eval — portable to
-#             ROCm via ROCm/vllm + ROCm/aiter, but a separate image)
-#   - molmo   (pins a different torch; optional perception backend)
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
@@ -42,17 +28,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CAPX_SIM=${CAPX_SIM} \
     MUJOCO_GL=egl \
     PYOPENGL_PLATFORM=egl
-    # Strix Halo (Ryzen AI Max, gfx1151) is supported natively by ROCm 7.2,
-    # so no HSA override is normally needed. If you hit "invalid device function"
-    # set HSA_OVERRIDE_GFX_VERSION in config.yaml to match your part, e.g.:
-    #   gfx1151 (Strix Halo):           11.5.1
-    #   gfx1103 (Phoenix/Strix laptop): 11.0.0
 
 WORKDIR /ryzers
 
-# ---------------------------------------------------------------------------
 # System deps: build toolchain + EGL/GL stack for MuJoCo, pyrender, open3d.
-# ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git wget curl ca-certificates cmake build-essential pkg-config \
         python3-dev \
@@ -64,16 +43,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN git config --global credential.helper store
 
-# ---------------------------------------------------------------------------
 # Pin-constraints that protect the base ROCm torch and match CaP-X's
 # uv override-dependencies. torch/torchvision are pinned to the base image's
 # installed versions so pip will NEVER pull a different (CUDA) build.
-# ---------------------------------------------------------------------------
 RUN python3 - <<'PY' > /ryzers/constraints.txt
 import torch, torchvision
 print(f"torch=={torch.__version__.split('+')[0]}")
 print(f"torchvision=={torchvision.__version__.split('+')[0]}")
 PY
+
 # Match CaP-X's uv override-dependencies and the Python 3.12 Robosuite
 # resolution in its lockfile. In particular, Robosuite 1.5.1 still calls the
 # pre-3.10 mj_fullM API, so allowing the current MuJoCo release breaks startup.
@@ -93,12 +71,10 @@ RUN printf '%s\n' \
         'pyglet==2.1.13' \
     >> /ryzers/constraints.txt && cat /ryzers/constraints.txt
 
-# ---------------------------------------------------------------------------
 # Clone CaP-X. Clone WITHOUT --recurse-submodules, then init only the submodules
 # the eval images actually use. This skips curobo (huge + nested CUDA submodules),
 # b1k (BEHAVIOR/Isaac Sim), and verl (RL training) — none needed for the
 # Robosuite/LIBERO eval path, and a large time/space saving.
-# ---------------------------------------------------------------------------
 RUN git clone https://github.com/capgym/cap-x /ryzers/cap-x \
     && cd /ryzers/cap-x && git checkout ${CAPX_REF} \
     && git submodule update --init \
@@ -110,12 +86,10 @@ RUN git clone https://github.com/capgym/cap-x /ryzers/cap-x \
 
 WORKDIR /ryzers/cap-x
 
-# ---------------------------------------------------------------------------
 # Base runtime deps (the PyPI-resolvable subset of [project.dependencies]).
 # Excludes torch/torchvision (kept from base) and anything CUDA-only.
 # FIX: include setuptools<81 — sam3 imports pkg_resources, removed in
 # setuptools>=81.
-# ---------------------------------------------------------------------------
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         "gymnasium>=0.29" "tyro>=0.8.5" "pydantic>=2.7" "rich>=13.7" \
         "scipy>=1.12" "matplotlib>=3.10" "imageio[ffmpeg]>=0.6.0" \
@@ -133,13 +107,11 @@ RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
 # pyrender after all of its runtime dependencies are present.
 RUN pip install --no-cache-dir --no-deps "pyrender==0.1.45"
 
-# ---------------------------------------------------------------------------
 # PyRoKi (JAX-based IK / trajopt — the DEFAULT motion layer; replaces cuRobo for
 # the Robosuite/LIBERO bench). CaP-X's uv.lock resolves jax/jaxlib to plain CPU
 # 0.4.29 wheels (no CUDA/ROCm jax plugin), so IK runs on CPU jax exactly as
 # upstream ships it. pyroki + jaxls pinned to the lockfile commits; --no-deps so
 # they can't re-resolve jax off the 0.4.29 pin.
-# ---------------------------------------------------------------------------
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         "jax==0.4.29" "jaxlib==0.4.29" \
         jaxlie jax_dataclasses jaxtyping loguru termcolor \
@@ -147,28 +119,22 @@ RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         "git+https://github.com/brentyi/jaxls.git@6fe7cf9d56223736b2c0272d080ec7346203c648" \
         "git+https://github.com/chungmin99/pyroki.git@95afccc22658c461ab1042a048ae4e9c24bc2a47"
 
-# ---------------------------------------------------------------------------
 # SAM3 (pure-PyTorch, runs on ROCm torch). Weights are GATED on HuggingFace —
 # request access at https://huggingface.co/facebook/sam3 and pass HF_TOKEN at
 # run time (the entrypoint logs in). See README for an ungated SAM2/OWLv2
 # alternative that needs no token.
-# ---------------------------------------------------------------------------
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         -e capx/third_party/sam3
 
-# ---------------------------------------------------------------------------
 # Contact-GraspNet (the uynitsuj PyTorch fork — no custom CUDA kernels).
 # FIX: --no-build-isolation — its setup.py imports numpy at build time; mirrors
 # CaP-X's uv `extra-build-dependencies: contact-graspnet-pytorch = ["numpy"]`.
-# ---------------------------------------------------------------------------
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         --no-build-isolation \
         -e capx/third_party/contact_graspnet_pytorch
 
-# ---------------------------------------------------------------------------
 # Simulator family (mutually exclusive — chosen by CAPX_SIM).
 # All editable submodule installs use --no-build-isolation (numpy at build time).
-# ---------------------------------------------------------------------------
 RUN if [ "$CAPX_SIM" = "libero" ]; then \
         echo ">>> Installing LIBERO-PRO stack"; \
         pip install --no-cache-dir -c /ryzers/constraints.txt \
@@ -197,10 +163,8 @@ RUN if [ "$CAPX_SIM" = "libero" ]; then \
 # puts `capx` on the path). --no-build-isolation so it sees the base torch.
 RUN pip install --no-cache-dir --no-deps --no-build-isolation -e .
 
-# ---------------------------------------------------------------------------
 # Entrypoint: optional HuggingFace login (SAM3 gated weights) + sign-of-life
-# test. Pass HF_TOKEN via config.yaml / -e to enable SAM3 weight download.
-# ---------------------------------------------------------------------------
+# test. Pass HF_TOKEN via config.yaml to enable SAM3 weight download.
 COPY test.sh /ryzers/test_capx.sh
 RUN chmod +x /ryzers/test_capx.sh
 

--- a/packages/robotics/capx/Dockerfile
+++ b/packages/robotics/capx/Dockerfile
@@ -127,7 +127,7 @@ RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         -e capx/third_party/sam3
 
-# Contact-GraspNet (the uynitsuj PyTorch fork — no custom CUDA kernels).
+# Contact-GraspNet (uynitsuj’s fork of elchun’s PyTorch port; no custom CUDA kernels).
 # FIX: --no-build-isolation — its setup.py imports numpy at build time; mirrors
 # CaP-X's uv `extra-build-dependencies: contact-graspnet-pytorch = ["numpy"]`.
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \

--- a/packages/robotics/capx/Dockerfile
+++ b/packages/robotics/capx/Dockerfile
@@ -62,6 +62,7 @@ PY
 RUN printf '%s\n' \
         'numpy==1.26.4' \
         'PyOpenGL==3.1.6' \
+        'matplotlib>=3.10,<3.11' \
         'opencv-python-headless<4.13' \
         'jax==0.4.29' \
         'jaxlib==0.4.29' \
@@ -92,7 +93,7 @@ WORKDIR /ryzers/cap-x
 # setuptools>=81.
 RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
         "gymnasium>=0.29" "tyro>=0.8.5" "pydantic>=2.7" "rich>=13.7" \
-        "scipy>=1.12" "matplotlib>=3.10" "imageio[ffmpeg]>=0.6.0" \
+        "scipy>=1.12" "matplotlib>=3.10,<3.11" "imageio[ffmpeg]>=0.6.0" \
         requests tqdm h5py einops decord pycocotools pyyaml omegaconf \
         open3d "robot_descriptions>=1.16.0" "yourdfpy>=0.0.56" "viser>=0.2.0" \
         "trimesh>=4.4.0" msgpack_numpy "ray==2.48.0" "mediapy>=1.2.5" \

--- a/packages/robotics/capx/Dockerfile
+++ b/packages/robotics/capx/Dockerfile
@@ -1,0 +1,202 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# CaP-X (https://github.com/capgym/cap-x) — Code-as-Policy agents for robot
+# manipulation — on AMD Ryzen AI via ROCm.
+#
+# This image runs the CaP-Gym EVAL path for two simulator families:
+#   - Robosuite (1.5.x)
+#   - LIBERO-PRO (robosuite 1.4.x)
+# Because the two pin conflicting robosuite versions, pick ONE per image with:
+#   --build-arg CAPX_SIM=robosuite   (default)   or   CAPX_SIM=libero
+#
+# The Ryzers default base (rocm/pytorch:...py3.12_pytorch_release_2.10.0) already
+# ships a ROCm-built torch/torchvision; we DO NOT reinstall torch so the ROCm
+# build is preserved. GPU work (SAM3, Contact-GraspNet) runs on ROCm torch;
+# MuJoCo renders via EGL on the AMD GPU; PyRoKi IK runs on CPU jax (matching
+# CaP-X upstream, whose lockfile pins plain CPU jax 0.4.29 — no GPU jax plugin).
+#
+# NOT included (out of scope for the eval image):
+#   - cuRobo  (hand-written CUDA/NVRTC kernels, no ROCm fork; gated off in the
+#             default Robosuite/LIBERO configs anyway — PyRoKi is the default
+#             motion layer)
+#   - verl / vllm / flash-attn  (CaP-RL TRAINING path, not eval — portable to
+#             ROCm via ROCm/vllm + ROCm/aiter, but a separate image)
+#   - molmo   (pins a different torch; optional perception backend)
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-lc"]
+
+# robosuite | libero
+ARG CAPX_SIM=robosuite
+# Pinned to an audited CaP-X commit so submodule gitlinks resolve to the exact
+# versions in CaP-X's uv.lock. Override to track upstream.
+ARG CAPX_REF=53e9966d7a8e2fa7494676772bccc35280f5c0ed
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_BREAK_SYSTEM_PACKAGES=1 \
+    CAPX_SIM=${CAPX_SIM} \
+    # MuJoCo headless rendering via EGL (OpenGL, not CUDA — works on AMD).
+    MUJOCO_GL=egl \
+    PYOPENGL_PLATFORM=egl
+    # Strix Halo (Ryzen AI Max, gfx1151) is supported natively by ROCm 7.2,
+    # so no HSA override is normally needed. If you hit "invalid device function"
+    # set HSA_OVERRIDE_GFX_VERSION in config.yaml to match your part, e.g.:
+    #   gfx1151 (Strix Halo):           11.5.1
+    #   gfx1103 (Phoenix/Strix laptop): 11.0.0
+
+WORKDIR /ryzers
+
+# ---------------------------------------------------------------------------
+# System deps: build toolchain + EGL/GL stack for MuJoCo, pyrender, open3d.
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git wget curl ca-certificates cmake build-essential pkg-config \
+        python3-dev \
+        libegl1 libgl1 libglib2.0-0 libgles2 \
+        libosmesa6 libosmesa6-dev \
+        libglew-dev libglfw3 libglfw3-dev \
+        ffmpeg \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global credential.helper store
+
+# ---------------------------------------------------------------------------
+# Pin-constraints that protect the base ROCm torch and match CaP-X's
+# uv override-dependencies. torch/torchvision are pinned to the base image's
+# installed versions so pip will NEVER pull a different (CUDA) build.
+# ---------------------------------------------------------------------------
+RUN python3 - <<'PY' > /ryzers/constraints.txt
+import torch, torchvision
+print(f"torch=={torch.__version__.split('+')[0]}")
+print(f"torchvision=={torchvision.__version__.split('+')[0]}")
+PY
+# Match CaP-X's uv override-dependencies (pyproject.toml [tool.uv]):
+#   numpy==1.26.4, PyOpenGL==3.1.6, opencv-python-headless<4.13, jax/jaxlib<0.4.30.
+# FIX: CaP-X also pins PyOpenGL-accelerate==3.1.6, but that version has no cp312
+# wheel and fails to compile on the base image's Python 3.12. -accelerate is an
+# optional perf add-on (not required), so we omit the pin and only constrain
+# PyOpenGL itself (pure-python, installs fine).
+RUN printf '%s\n' \
+        'numpy==1.26.4' \
+        'PyOpenGL==3.1.6' \
+        'opencv-python-headless<4.13' \
+        'jax==0.4.29' \
+        'jaxlib==0.4.29' \
+    >> /ryzers/constraints.txt && cat /ryzers/constraints.txt
+
+# ---------------------------------------------------------------------------
+# Clone CaP-X. Clone WITHOUT --recurse-submodules, then init only the submodules
+# the eval images actually use. This skips curobo (huge + nested CUDA submodules),
+# b1k (BEHAVIOR/Isaac Sim), and verl (RL training) — none needed for the
+# Robosuite/LIBERO eval path, and a large time/space saving.
+# ---------------------------------------------------------------------------
+RUN git clone https://github.com/capgym/cap-x /ryzers/cap-x \
+    && cd /ryzers/cap-x && git checkout ${CAPX_REF} \
+    && git submodule update --init \
+        capx/third_party/sam3 \
+        capx/third_party/contact_graspnet_pytorch \
+        capx/third_party/robosuite \
+        capx/third_party/LIBERO-PRO \
+        capx/third_party/libero_dependencies/robosuite
+
+WORKDIR /ryzers/cap-x
+
+# ---------------------------------------------------------------------------
+# Base runtime deps (the PyPI-resolvable subset of [project.dependencies]).
+# Excludes torch/torchvision (kept from base) and anything CUDA-only.
+# FIX: include setuptools<81 — sam3 imports pkg_resources, removed in
+# setuptools>=81.
+# ---------------------------------------------------------------------------
+RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
+        "gymnasium>=0.29" "tyro>=0.8.5" "pydantic>=2.7" "rich>=13.7" \
+        "scipy>=1.12" "matplotlib>=3.10" "imageio[ffmpeg]>=0.6.0" \
+        requests tqdm h5py einops decord pycocotools pyyaml omegaconf \
+        open3d "robot_descriptions>=1.16.0" "yourdfpy>=0.0.56" "viser>=0.2.0" \
+        "trimesh>=4.4.0" msgpack_numpy "ray==2.48.0" "mediapy>=1.2.5" \
+        uvicorn fastapi "transformers<5.0" openai pyrender \
+        "opencv-python-headless<4.13" "pillow>=10" cloudpickle \
+        "setuptools<81"
+
+# ---------------------------------------------------------------------------
+# PyRoKi (JAX-based IK / trajopt — the DEFAULT motion layer; replaces cuRobo for
+# the Robosuite/LIBERO bench). CaP-X's uv.lock resolves jax/jaxlib to plain CPU
+# 0.4.29 wheels (no CUDA/ROCm jax plugin), so IK runs on CPU jax exactly as
+# upstream ships it. pyroki + jaxls pinned to the lockfile commits; --no-deps so
+# they can't re-resolve jax off the 0.4.29 pin.
+# ---------------------------------------------------------------------------
+RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
+        "jax==0.4.29" "jaxlib==0.4.29" \
+        jaxlie jax_dataclasses jaxtyping loguru termcolor \
+    && pip install --no-cache-dir -c /ryzers/constraints.txt --no-deps \
+        "git+https://github.com/brentyi/jaxls.git@6fe7cf9d56223736b2c0272d080ec7346203c648" \
+        "git+https://github.com/chungmin99/pyroki.git@95afccc22658c461ab1042a048ae4e9c24bc2a47"
+
+# ---------------------------------------------------------------------------
+# SAM3 (pure-PyTorch, runs on ROCm torch). Weights are GATED on HuggingFace —
+# request access at https://huggingface.co/facebook/sam3 and pass HF_TOKEN at
+# run time (the entrypoint logs in). See README for an ungated SAM2/OWLv2
+# alternative that needs no token.
+# ---------------------------------------------------------------------------
+RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
+        -e capx/third_party/sam3
+
+# ---------------------------------------------------------------------------
+# Contact-GraspNet (the uynitsuj PyTorch fork — no custom CUDA kernels).
+# FIX: --no-build-isolation — its setup.py imports numpy at build time; mirrors
+# CaP-X's uv `extra-build-dependencies: contact-graspnet-pytorch = ["numpy"]`.
+# ---------------------------------------------------------------------------
+RUN pip install --no-cache-dir -c /ryzers/constraints.txt \
+        --no-build-isolation \
+        -e capx/third_party/contact_graspnet_pytorch
+
+# ---------------------------------------------------------------------------
+# Simulator family (mutually exclusive — chosen by CAPX_SIM).
+# All editable submodule installs use --no-build-isolation (numpy at build time).
+# ---------------------------------------------------------------------------
+RUN if [ "$CAPX_SIM" = "libero" ]; then \
+        echo ">>> Installing LIBERO-PRO stack"; \
+        pip install --no-cache-dir -c /ryzers/constraints.txt \
+            "easydict==1.9" "robomimic==0.2.0" "einops==0.4.1" \
+            "thop==0.1.1-2209072238" "bddl==1.0.1" "future==0.18.2" \
+            "gym==0.25.2" scikit-learn && \
+        pip install --no-cache-dir -c /ryzers/constraints.txt --no-build-isolation \
+            -e capx/third_party/libero_dependencies/robosuite && \
+        pip install --no-cache-dir -c /ryzers/constraints.txt --no-build-isolation \
+            -e capx/third_party/LIBERO-PRO && \
+        : "FIX: LIBERO pins future==0.18.2 whose standard_library does import imp" \
+          "(removed in py3.12), which breaks pyglet->pyrender->GraspNet server." \
+          "future>=1.0 drops the imp import and LIBERO still imports fine." && \
+        pip install --no-cache-dir "future>=1.0" && \
+        : "FIX: LIBERO prompts for a dataset path on first import via input();" \
+          "pre-seed ~/.libero/config.yaml at build time (answer N) so runtime" \
+          "is non-interactive." && \
+        printf 'N\n' | python3 -c "import libero" || true ; \
+    else \
+        echo ">>> Installing Robosuite stack"; \
+        pip install --no-cache-dir -c /ryzers/constraints.txt --no-build-isolation \
+            -e capx/third_party/robosuite ; \
+    fi
+
+# Install the capx package itself WITHOUT deps (deps handled above; this just
+# puts `capx` on the path). --no-build-isolation so it sees the base torch.
+RUN pip install --no-cache-dir --no-deps --no-build-isolation -e .
+
+# ---------------------------------------------------------------------------
+# Entrypoint: optional HuggingFace login (SAM3 gated weights) + sign-of-life
+# test. Pass HF_TOKEN via config.yaml / -e to enable SAM3 weight download.
+# ---------------------------------------------------------------------------
+COPY test.sh /ryzers/test_capx.sh
+RUN chmod +x /ryzers/test_capx.sh
+
+RUN echo -e '#!/bin/bash\n\
+if [ -n "$HF_TOKEN" ]; then\n\
+  hf auth login --token "$HF_TOKEN" --add-to-git-credential >/dev/null 2>&1 || true\n\
+fi\n\
+exec "$@"' > /ryzers/entrypoint.sh && chmod +x /ryzers/entrypoint.sh
+
+ENTRYPOINT ["/ryzers/entrypoint.sh"]
+CMD /ryzers/test_capx.sh

--- a/packages/robotics/capx/README.md
+++ b/packages/robotics/capx/README.md
@@ -9,7 +9,7 @@ This Ryzer runs the **CaP-Gym evaluation path** on AMD Ryzen AI hardware: a codi
 
 Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet) on ROCm PyTorch, and MuJoCo rendering via EGL on the AMD GPU. Motion planning (PyRoKi IK) runs on CPU `jax`, exactly as CaP-X ships upstream.
 
-> **Validated on:** AMD Ryzen AI MAX+ 395 (Radeon 8060S, gfx1151) / Strix Halo, Ubuntu 24.04, ROCm 7.2.
+> **Validated on:** AMD Ryzen AI MAX+ 395 (Radeon 8060S, gfx1151) / Strix Halo, Ubuntu 24.04, ROCm 7.2.2, PyTorch 2.10.
 
 ---
 
@@ -18,7 +18,7 @@ Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet
 | Component | Status | Notes |
 |---|---|---|
 | Robosuite eval | ✅ | `--build-arg CAPX_SIM=robosuite` (default) |
-| LIBERO-PRO eval | ✅ | `--build-arg CAPX_SIM=libero` |
+| LIBERO-PRO eval | ⚠️ | Image path retained but not validated by this branch |
 | SAM3 / SAM2 / OWLv2 perception | ✅ | ROCm PyTorch |
 | Contact-GraspNet | ✅ | PyTorch fork, no custom CUDA kernels |
 | PyRoKi IK / trajopt | ✅ | CPU `jax` (matches upstream lockfile) |
@@ -38,7 +38,7 @@ Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet
 ryzers build capx
 ryzers run                 # runs the sign-of-life test
 
-# LIBERO-PRO — set CAPX_SIM=libero in config.yaml build_arguments first,
+# LIBERO-PRO (experimental) — set CAPX_SIM=libero in config.yaml first,
 # then build under a distinct name:
 ryzers build --name capx-libero capx
 ryzers run --name capx-libero
@@ -111,7 +111,7 @@ Get a key at <https://openrouter.ai/keys> and set `OPENROUTER_API_KEY` in [`conf
 # inside `ryzers run bash`
 cd /ryzers/cap-x
 echo "$OPENROUTER_API_KEY" > .openrouterkey
-uv run --no-sync --active capx/serving/openrouter_server.py \
+python3 capx/serving/openrouter_server.py \
     --key-file .openrouterkey --port 8110 &
 
 # Robosuite single-turn benchmark
@@ -213,6 +213,9 @@ Outputs (per-trial rewards + videos) land in `outputs/<model>/<config>/` — sur
 This package bakes in several fixes discovered while porting CaP-X (whose dependency set is `uv`-native and assumes CUDA) to a ROCm PyTorch base on Python 3.12:
 
 - **torch is never reinstalled.** A generated `constraints.txt` pins the base image's ROCm torch/torchvision so no transitive dep can pull a CUDA wheel.
+- **Robosuite simulator versions are locked.** `mujoco==3.5.0` and `mink==1.1.0` match CaP-X's lockfile; newer MuJoCo releases changed `mj_fullM` and break the pinned Robosuite 1.5.1 fork.
+- **The package pins its base image** to ROCm 7.2.2 / PyTorch 2.10 so a future repository-wide default change cannot silently alter this validated environment.
+- **`pyrender==0.1.45` is installed with CaP-X's PyOpenGL 3.1.6 override.** Its stale package metadata requests PyOpenGL 3.1.0, so pip's normal resolver cannot reproduce the upstream uv lock directly.
 - **`jax` is CPU-only**, matching CaP-X's lockfile (plain `jax==0.4.29`, no GPU plugin). PyRoKi IK is a CPU workload upstream too — this is faithful, not a downgrade.
 - **`PyOpenGL-accelerate==3.1.6` pin dropped** — it has no cp312 wheel and fails to compile; it's an optional perf shim.
 - **`setuptools<81`** — SAM3 imports `pkg_resources`, removed in setuptools ≥81.

--- a/packages/robotics/capx/README.md
+++ b/packages/robotics/capx/README.md
@@ -1,33 +1,13 @@
 # CaP-X
 
-A ROCm-enabled container for [**CaP-X**](https://github.com/capgym/cap-x) — *Code-as-Policies eXtended*, a framework for benchmarking and improving coding agents for robot manipulation (NVIDIA / UC Berkeley / Stanford / CMU).
+A ROCm-enabled container for [**CaP-X**](https://github.com/capgym/cap-x) - *Code-as-Policies eXtended*, a framework for benchmarking and improving coding agents for robot manipulation.
 
-This Ryzer runs the **CaP-Gym evaluation path** on AMD Ryzen AI hardware: a coding-agent LLM generates Python that composes perception + control primitives to solve manipulation tasks in simulation. It supports two simulator families:
+This Ryzer runs the **CaP-Gym evaluation path** on AMD Ryzen AI hardware: a coding-agent LLM generates Python that composes perception + control primitives to solve manipulation tasks in simulation. It supports two evaluation suites:
 
-- **Robosuite** (1.5.x)
-- **LIBERO-PRO** (robosuite 1.4.x)
+- **Native Robosuite environments** (Robosuite 1.5.x)
+- **LIBERO-PRO environments** (built on Robosuite 1.4.x)
 
-Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet) on ROCm PyTorch, and MuJoCo rendering via EGL on the AMD GPU. Motion planning (PyRoKi IK) runs on CPU `jax`, exactly as CaP-X ships upstream.
-
-> **Validated on:** AMD Ryzen AI MAX+ 395 (Radeon 8060S, gfx1151) / Strix Halo, Ubuntu 24.04, ROCm 7.2.2, PyTorch 2.10.
-
----
-
-## What's included vs. not
-
-| Component | Status | Notes |
-|---|---|---|
-| Robosuite eval | ✅ | `--build-arg CAPX_SIM=robosuite` (default) |
-| LIBERO-PRO eval | ⚠️ | Image path retained but not validated by this branch |
-| SAM3 / SAM2 / OWLv2 perception | ✅ | ROCm PyTorch |
-| Contact-GraspNet | ✅ | PyTorch fork, no custom CUDA kernels |
-| PyRoKi IK / trajopt | ✅ | CPU `jax` (matches upstream lockfile) |
-| MuJoCo rendering | ✅ | EGL on AMD GPU |
-| cuRobo | ❌ | Hand-written CUDA/NVRTC kernels, no ROCm fork. Gated off in the default configs anyway — PyRoKi is the default motion layer. |
-| CaP-RL (verl / vLLM / flash-attn) | ❌ | The training path. Portable to ROCm (verl ships ROCm Dockerfiles using ROCm/vLLM + ROCm/aiter), but it's a separate, larger image. |
-| BEHAVIOR / Isaac Sim (`b1k`) | ❌ | NVIDIA Isaac Sim, out of scope. |
-
-> Robosuite (1.5.x) and LIBERO (robosuite 1.4.x) pin **conflicting** robosuite versions, so each image targets exactly one family — pick it at build time.
+Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet) on ROCm PyTorch, and MuJoCo rendering via EGL on the AMD GPU. Motion planning (PyRoKi IK) runs on CPU `jax`.
 
 ---
 
@@ -38,7 +18,7 @@ Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet
 ryzers build capx
 ryzers run                 # runs the sign-of-life test
 
-# LIBERO-PRO (experimental) — set CAPX_SIM=libero in config.yaml first,
+# LIBERO-PRO (experimental) - set CAPX_SIM=libero in config.yaml first,
 # then build under a distinct name:
 ryzers build --name capx-libero capx
 ryzers run --name capx-libero
@@ -46,9 +26,9 @@ ryzers run --name capx-libero
 
 `ryzers run` executes [`test.sh`](test.sh), which has **three stages**:
 
-1. **Sign-of-life** — ROCm torch sees the GPU; the stack + simulator import; MuJoCo renders via EGL.
-2. **Oracle eval (always runs, no LLM / no keys)** — runs a full CaP-Gym episode using the environment's ground-truth `oracle_code` through the real simulator + PyRoKi IK pipeline, and asserts task **success (reward 1.0)**. This is the deterministic correctness check for the eval pipeline on ROCm. It needs no API key.
-3. **LLM eval (optional)** — if `CAPX_LLM_SERVER_URL` is set, runs a short real *agentic* eval (the LLM writes code → the sim executes it → reward) against any OpenAI-compatible endpoint.
+1. **Sign-of-life** - ROCm torch sees the GPU; the stack + simulator import; MuJoCo renders via EGL.
+2. **Oracle eval (always runs, no LLM / no keys)** - runs a full CaP-Gym episode using the environment's ground-truth `oracle_code` through the real simulator + PyRoKi IK pipeline, and asserts task **success (reward 1.0)**. This is the deterministic correctness check for the eval pipeline on ROCm. It needs no API key.
+3. **LLM eval (optional)** - if `CAPX_LLM_SERVER_URL` is set, runs a short real *agentic* eval (the LLM writes code → the sim executes it → reward) against any OpenAI-compatible endpoint.
 
 Expected tail (stages 1–2; stage 3 skipped when no LLM is configured):
 
@@ -64,13 +44,13 @@ PyRoKi ready (warmed JAX JIT) after 19s
 Success
 ORACLE EVAL PASSED (reward 1.0)
 ================ [3/3] LLM eval (optional) ================
-SKIPPED — set CAPX_LLM_SERVER_URL ...
+SKIPPED - set CAPX_LLM_SERVER_URL ...
 ================ CaP-X tests PASSED ================
 ```
 
 ### Enabling the LLM eval stage
 
-Set these env vars (in `config.yaml` or via `-e`) to make `ryzers run` exercise a
+Set these env vars (in `config.yaml`) to make `ryzers run` exercise a
 real agentic eval against an OpenAI-compatible endpoint:
 
 | Variable | Meaning | Example |
@@ -78,16 +58,6 @@ real agentic eval against an OpenAI-compatible endpoint:
 | `CAPX_LLM_SERVER_URL` | OpenAI-compatible `/chat/completions` URL | `http://127.0.0.1:11434/v1/chat/completions` |
 | `CAPX_LLM_MODEL` | model name to request | `gemma4`, `google/gemini-3.1-pro-preview` |
 | `CAPX_LLM_TRIALS` | number of trials (default 2) | `2` |
-
-> **Disclaimer.** The LLM-eval stage was validated end-to-end against a **local
-> llama.cpp `llama-server`** (built with HIP, serving a vision GGUF) — the full
-> loop closes: LLM → code → SAM3/GraspNet/PyRoKi perception → sim → reward +
-> saved artifacts. It works identically against **OpenRouter** or any other
-> OpenAI-compatible server. Task *success rate* depends entirely on the model:
-> small local models often write buggy code and score low; that is a model
-> outcome, not an infra problem. The **oracle eval (stage 2)** is the
-> infra-correctness check and always returns reward 1.0 when the ROCm pipeline
-> is healthy.
 
 For an interactive shell (to launch full benchmark evals yourself):
 
@@ -103,7 +73,7 @@ Evals need two things: an **LLM endpoint** and (optionally) **perception weights
 
 ### 1. LLM provider
 
-#### Option A — OpenRouter (default, like upstream)
+#### Option A - OpenRouter (default, like upstream)
 
 Get a key at <https://openrouter.ai/keys> and set `OPENROUTER_API_KEY` in [`config.yaml`](config.yaml). Inside the container, start CaP-X's OpenRouter proxy (it exposes an OpenAI-compatible API on `:8110`), then launch an eval:
 
@@ -123,9 +93,9 @@ python3 capx/envs/launch.py \
 
 The perception servers (SAM3, GraspNet, PyRoKi) listed in the YAML's `api_servers` are **auto-launched** by `launch.py`.
 
-#### Option B — Local / on-prem OpenAI-compatible LLM
+#### Option B - Local / on-prem OpenAI-compatible LLM
 
-CaP-X's LLM client (`capx/llm/client.py`) posts a standard OpenAI `chat/completions` payload to whatever `--server-url` you give it, for any model name not in its built-in OpenRouter/GPT/Claude lists. So **any** OpenAI-compatible server works — run it on the host and point the eval at it.
+CaP-X's LLM client (`capx/llm/client.py`) posts a standard OpenAI `chat/completions` payload to whatever `--server-url` you give it, for any model name not in its built-in OpenRouter/GPT/Claude lists. So **any** OpenAI-compatible server works - run it on the host and point the eval at it.
 
 Two ROCm-friendly servers:
 
@@ -136,7 +106,7 @@ Two ROCm-friendly servers:
                --mmproj mmproj-gemma-4-12B-it-bf16.gguf \
                --host 0.0.0.0 --port 11434 --n-gpu-layers 999 --jinja
   ```
-- **vLLM (ROCm build)** or **Ollama (ROCm)** — both expose `/v1/chat/completions`.
+- **vLLM (ROCm build)** or **Ollama (ROCm)** - both expose `/v1/chat/completions`.
 
 Then, inside the container (Ryzers uses host networking, so `127.0.0.1` reaches the host server):
 
@@ -153,11 +123,11 @@ python3 capx/envs/launch.py \
 
 ### 2. Perception weights
 
-#### Option A — SAM3 (upstream default, gated)
+#### Option A - SAM3 (upstream default, gated)
 
 SAM3 weights (`facebook/sam3`) are **gated** on HuggingFace. Request access at <https://huggingface.co/facebook/sam3>, create a token at <https://huggingface.co/settings/tokens>, and set `HF_TOKEN` in `config.yaml`. The entrypoint logs in and the weights download on first use (cached via the `~/.cache/huggingface` volume mount). The default `env_configs/**` YAMLs already use SAM3.
 
-#### Option B — SAM2 + OWLv2 (ungated, no token)
+#### Option B - SAM2 + OWLv2 (ungated, no token)
 
 If you don't have SAM3 access, swap to SAM2 + OWLv2, which are **not gated**. The control APIs already support this via a `use_sam3=False` path. Inside the container:
 
@@ -191,7 +161,7 @@ trials: 10
 num_workers: 2
 ```
 
-> The SAM2 server is hard-wired to port **8113** and OWLv2 to **8117** (`capx/integrations/vision/{sam2,owlvit}.py`) — match those in the config.
+> The SAM2 server is hard-wired to port **8113** and OWLv2 to **8117** (`capx/integrations/vision/{sam2,owlvit}.py`) - match those in the config.
 
 ### LIBERO-PRO example
 
@@ -204,31 +174,7 @@ python3 capx/envs/launch.py \
     --total-trials 5 --num-workers 1
 ```
 
-Outputs (per-trial rewards + videos) land in `outputs/<model>/<config>/` — surfaced on the host via the `outputs` volume mount.
-
----
-
-## Notes, fixes & troubleshooting
-
-This package bakes in several fixes discovered while porting CaP-X (whose dependency set is `uv`-native and assumes CUDA) to a ROCm PyTorch base on Python 3.12:
-
-- **torch is never reinstalled.** A generated `constraints.txt` pins the base image's ROCm torch/torchvision so no transitive dep can pull a CUDA wheel.
-- **Robosuite simulator versions are locked.** `mujoco==3.5.0` and `mink==1.1.0` match CaP-X's lockfile; newer MuJoCo releases changed `mj_fullM` and break the pinned Robosuite 1.5.1 fork.
-- **The package pins its base image** to ROCm 7.2.2 / PyTorch 2.10 so a future repository-wide default change cannot silently alter this validated environment.
-- **`pyrender==0.1.45` is installed with CaP-X's PyOpenGL 3.1.6 override.** Its stale package metadata requests PyOpenGL 3.1.0, so pip's normal resolver cannot reproduce the upstream uv lock directly.
-- **`jax` is CPU-only**, matching CaP-X's lockfile (plain `jax==0.4.29`, no GPU plugin). PyRoKi IK is a CPU workload upstream too — this is faithful, not a downgrade.
-- **`PyOpenGL-accelerate==3.1.6` pin dropped** — it has no cp312 wheel and fails to compile; it's an optional perf shim.
-- **`setuptools<81`** — SAM3 imports `pkg_resources`, removed in setuptools ≥81.
-- **`--no-build-isolation`** on the editable submodule installs (robosuite, contact_graspnet, LIBERO-PRO) — their `setup.py` import numpy at build time.
-- **LIBERO `future>=1.0`** — LIBERO pins `future==0.18.2`, whose `standard_library` does `import imp` (removed in Python 3.12), which breaks `pyglet → pyrender →` the GraspNet server. Upgrading `future` fixes it and LIBERO still imports.
-- **LIBERO non-interactive init** — LIBERO calls `input()` for a dataset path on first import; the build pre-seeds `~/.libero/config.yaml` so runtime is non-interactive.
-- **Trimmed submodule clone** — only the submodules the eval needs are inited (skips curobo/b1k/verl), saving significant build time and image size.
-
-Other tips:
-
-- **`invalid device function` / no GPU:** your part may need an HSA override. Set `HSA_OVERRIDE_GFX_VERSION` in `config.yaml` (e.g. `11.5.1` for gfx1151, `11.0.0` for gfx1103).
-- **Large local models are slow on an iGPU.** A 12B-class vision model is a good speed/quality balance; smaller models often write buggy code and score low — that's a model-quality outcome, not an infra problem.
-- **Trial timeout:** very slow local models can exceed CaP-X's per-trial wall-clock (`TRIAL_TIMEOUT_SECONDS` in `capx/envs/runner.py`). Lower `--max-tokens`, use fewer workers (less GPU contention), or raise the timeout.
+Outputs (per-trial rewards + videos) land in `outputs/<model>/<config>/` - surfaced on the host via the `outputs` volume mount.
 
 ---
 

--- a/packages/robotics/capx/README.md
+++ b/packages/robotics/capx/README.md
@@ -1,0 +1,236 @@
+# CaP-X
+
+A ROCm-enabled container for [**CaP-X**](https://github.com/capgym/cap-x) — *Code-as-Policies eXtended*, a framework for benchmarking and improving coding agents for robot manipulation (NVIDIA / UC Berkeley / Stanford / CMU).
+
+This Ryzer runs the **CaP-Gym evaluation path** on AMD Ryzen AI hardware: a coding-agent LLM generates Python that composes perception + control primitives to solve manipulation tasks in simulation. It supports two simulator families:
+
+- **Robosuite** (1.5.x)
+- **LIBERO-PRO** (robosuite 1.4.x)
+
+Everything GPU-bound runs on ROCm: the perception models (SAM3, Contact-GraspNet) on ROCm PyTorch, and MuJoCo rendering via EGL on the AMD GPU. Motion planning (PyRoKi IK) runs on CPU `jax`, exactly as CaP-X ships upstream.
+
+> **Validated on:** AMD Ryzen AI MAX+ 395 (Radeon 8060S, gfx1151) / Strix Halo, Ubuntu 24.04, ROCm 7.2.
+
+---
+
+## What's included vs. not
+
+| Component | Status | Notes |
+|---|---|---|
+| Robosuite eval | ✅ | `--build-arg CAPX_SIM=robosuite` (default) |
+| LIBERO-PRO eval | ✅ | `--build-arg CAPX_SIM=libero` |
+| SAM3 / SAM2 / OWLv2 perception | ✅ | ROCm PyTorch |
+| Contact-GraspNet | ✅ | PyTorch fork, no custom CUDA kernels |
+| PyRoKi IK / trajopt | ✅ | CPU `jax` (matches upstream lockfile) |
+| MuJoCo rendering | ✅ | EGL on AMD GPU |
+| cuRobo | ❌ | Hand-written CUDA/NVRTC kernels, no ROCm fork. Gated off in the default configs anyway — PyRoKi is the default motion layer. |
+| CaP-RL (verl / vLLM / flash-attn) | ❌ | The training path. Portable to ROCm (verl ships ROCm Dockerfiles using ROCm/vLLM + ROCm/aiter), but it's a separate, larger image. |
+| BEHAVIOR / Isaac Sim (`b1k`) | ❌ | NVIDIA Isaac Sim, out of scope. |
+
+> Robosuite (1.5.x) and LIBERO (robosuite 1.4.x) pin **conflicting** robosuite versions, so each image targets exactly one family — pick it at build time.
+
+---
+
+## Build & Run
+
+```bash
+# Robosuite (default)
+ryzers build capx
+ryzers run                 # runs the sign-of-life test
+
+# LIBERO-PRO — set CAPX_SIM=libero in config.yaml build_arguments first,
+# then build under a distinct name:
+ryzers build --name capx-libero capx
+ryzers run --name capx-libero
+```
+
+`ryzers run` executes [`test.sh`](test.sh), which has **three stages**:
+
+1. **Sign-of-life** — ROCm torch sees the GPU; the stack + simulator import; MuJoCo renders via EGL.
+2. **Oracle eval (always runs, no LLM / no keys)** — runs a full CaP-Gym episode using the environment's ground-truth `oracle_code` through the real simulator + PyRoKi IK pipeline, and asserts task **success (reward 1.0)**. This is the deterministic correctness check for the eval pipeline on ROCm. It needs no API key.
+3. **LLM eval (optional)** — if `CAPX_LLM_SERVER_URL` is set, runs a short real *agentic* eval (the LLM writes code → the sim executes it → reward) against any OpenAI-compatible endpoint.
+
+Expected tail (stages 1–2; stage 3 skipped when no LLM is configured):
+
+```
+================ [1/3] CaP-X / ROCm sign-of-life ================
+GPU ok  : True
+  device 0: Radeon 8060S Graphics
+capx + pyroki import OK
+robosuite 1.5.1 import OK
+EGL render OK, frame shape (64, 64, 3)
+================ [2/3] Oracle eval (no LLM): franka_robosuite_pick_place_code_env ================
+PyRoKi ready (warmed JAX JIT) after 19s
+Success
+ORACLE EVAL PASSED (reward 1.0)
+================ [3/3] LLM eval (optional) ================
+SKIPPED — set CAPX_LLM_SERVER_URL ...
+================ CaP-X tests PASSED ================
+```
+
+### Enabling the LLM eval stage
+
+Set these env vars (in `config.yaml` or via `-e`) to make `ryzers run` exercise a
+real agentic eval against an OpenAI-compatible endpoint:
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `CAPX_LLM_SERVER_URL` | OpenAI-compatible `/chat/completions` URL | `http://127.0.0.1:11434/v1/chat/completions` |
+| `CAPX_LLM_MODEL` | model name to request | `gemma4`, `google/gemini-3.1-pro-preview` |
+| `CAPX_LLM_TRIALS` | number of trials (default 2) | `2` |
+
+> **Disclaimer.** The LLM-eval stage was validated end-to-end against a **local
+> llama.cpp `llama-server`** (built with HIP, serving a vision GGUF) — the full
+> loop closes: LLM → code → SAM3/GraspNet/PyRoKi perception → sim → reward +
+> saved artifacts. It works identically against **OpenRouter** or any other
+> OpenAI-compatible server. Task *success rate* depends entirely on the model:
+> small local models often write buggy code and score low; that is a model
+> outcome, not an infra problem. The **oracle eval (stage 2)** is the
+> infra-correctness check and always returns reward 1.0 when the ROCm pipeline
+> is healthy.
+
+For an interactive shell (to launch full benchmark evals yourself):
+
+```bash
+ryzers run bash
+```
+
+---
+
+## Running an evaluation
+
+Evals need two things: an **LLM endpoint** and (optionally) **perception weights**.
+
+### 1. LLM provider
+
+#### Option A — OpenRouter (default, like upstream)
+
+Get a key at <https://openrouter.ai/keys> and set `OPENROUTER_API_KEY` in [`config.yaml`](config.yaml). Inside the container, start CaP-X's OpenRouter proxy (it exposes an OpenAI-compatible API on `:8110`), then launch an eval:
+
+```bash
+# inside `ryzers run bash`
+cd /ryzers/cap-x
+echo "$OPENROUTER_API_KEY" > .openrouterkey
+uv run --no-sync --active capx/serving/openrouter_server.py \
+    --key-file .openrouterkey --port 8110 &
+
+# Robosuite single-turn benchmark
+python3 capx/envs/launch.py \
+    --config-path env_configs/cube_stack/franka_robosuite_cube_stack.yaml \
+    --model "openrouter/google/gemini-3.1-pro-preview" \
+    --total-trials 10 --num-workers 4
+```
+
+The perception servers (SAM3, GraspNet, PyRoKi) listed in the YAML's `api_servers` are **auto-launched** by `launch.py`.
+
+#### Option B — Local / on-prem OpenAI-compatible LLM
+
+CaP-X's LLM client (`capx/llm/client.py`) posts a standard OpenAI `chat/completions` payload to whatever `--server-url` you give it, for any model name not in its built-in OpenRouter/GPT/Claude lists. So **any** OpenAI-compatible server works — run it on the host and point the eval at it.
+
+Two ROCm-friendly servers:
+
+- **llama.cpp `llama-server`** (built with HIP for your GFX arch):
+  ```bash
+  # on the host, serve a vision-capable GGUF (CaP-X sends image prompts)
+  llama-server --model gemma-4-12B-it-Q4_K_M.gguf \
+               --mmproj mmproj-gemma-4-12B-it-bf16.gguf \
+               --host 0.0.0.0 --port 11434 --n-gpu-layers 999 --jinja
+  ```
+- **vLLM (ROCm build)** or **Ollama (ROCm)** — both expose `/v1/chat/completions`.
+
+Then, inside the container (Ryzers uses host networking, so `127.0.0.1` reaches the host server):
+
+```bash
+cd /ryzers/cap-x
+python3 capx/envs/launch.py \
+    --config-path env_configs/cube_stack/franka_robosuite_cube_stack.yaml \
+    --model gemma-4-12B-it \
+    --server-url http://127.0.0.1:11434/v1/chat/completions \
+    --total-trials 10 --num-workers 2
+```
+
+> **Vision is required.** CaP-X sends `image_url` content, so the served model must accept images (e.g. a `-VL` / multimodal model with its `mmproj`). A text-only model will not work for the perception-grounded configs.
+
+### 2. Perception weights
+
+#### Option A — SAM3 (upstream default, gated)
+
+SAM3 weights (`facebook/sam3`) are **gated** on HuggingFace. Request access at <https://huggingface.co/facebook/sam3>, create a token at <https://huggingface.co/settings/tokens>, and set `HF_TOKEN` in `config.yaml`. The entrypoint logs in and the weights download on first use (cached via the `~/.cache/huggingface` volume mount). The default `env_configs/**` YAMLs already use SAM3.
+
+#### Option B — SAM2 + OWLv2 (ungated, no token)
+
+If you don't have SAM3 access, swap to SAM2 + OWLv2, which are **not gated**. The control APIs already support this via a `use_sam3=False` path. Inside the container:
+
+```bash
+cd /ryzers/cap-x
+# register an ungated-perception API variant
+cat >> capx/integrations/__init__.py <<'PY'
+register_api("FrankaControlApiSam2", lambda env: FrankaControlApi(env, use_sam3=False))
+PY
+```
+
+Then write a config that points `apis:` at `FrankaControlApiSam2` and swaps the SAM3 `api_server` for the SAM2 + OWLv2 servers:
+
+```yaml
+# env_configs/cube_stack/franka_robosuite_cube_stack_sam2.yaml
+env:
+  _target_: capx.envs.tasks.franka.franka_pick_place.FrankaPickPlaceCodeEnv
+  cfg:
+    _target_: capx.envs.tasks.base.CodeExecEnvConfig
+    low_level: franka_robosuite_cubes_low_level
+    privileged: false
+    apis: [FrankaControlApiSam2]
+api_servers:
+  - {_target_: capx.serving.launch_owlvit_server.main, port: 8117, host: 127.0.0.1}
+  - {_target_: capx.serving.launch_sam2_server.main, device: cuda, port: 8113, host: 127.0.0.1}
+  - {_target_: capx.serving.launch_contact_graspnet_server.main, port: 8115, host: 127.0.0.1}
+  - {_target_: capx.serving.launch_pyroki_server.main, port: 8116, host: 127.0.0.1, robot: panda_description, target_link: panda_hand}
+record_video: true
+output_dir: ./outputs/eval_robosuite_cube_stack_sam2
+trials: 10
+num_workers: 2
+```
+
+> The SAM2 server is hard-wired to port **8113** and OWLv2 to **8117** (`capx/integrations/vision/{sam2,owlvit}.py`) — match those in the config.
+
+### LIBERO-PRO example
+
+```bash
+# inside `ryzers run bash` (libero image), with an LLM server reachable
+cd /ryzers/cap-x
+python3 capx/envs/launch.py \
+    --config-path env_configs/libero/franka_libero_spatial_0.yaml \
+    --model <your-model> --server-url <your-endpoint> \
+    --total-trials 5 --num-workers 1
+```
+
+Outputs (per-trial rewards + videos) land in `outputs/<model>/<config>/` — surfaced on the host via the `outputs` volume mount.
+
+---
+
+## Notes, fixes & troubleshooting
+
+This package bakes in several fixes discovered while porting CaP-X (whose dependency set is `uv`-native and assumes CUDA) to a ROCm PyTorch base on Python 3.12:
+
+- **torch is never reinstalled.** A generated `constraints.txt` pins the base image's ROCm torch/torchvision so no transitive dep can pull a CUDA wheel.
+- **`jax` is CPU-only**, matching CaP-X's lockfile (plain `jax==0.4.29`, no GPU plugin). PyRoKi IK is a CPU workload upstream too — this is faithful, not a downgrade.
+- **`PyOpenGL-accelerate==3.1.6` pin dropped** — it has no cp312 wheel and fails to compile; it's an optional perf shim.
+- **`setuptools<81`** — SAM3 imports `pkg_resources`, removed in setuptools ≥81.
+- **`--no-build-isolation`** on the editable submodule installs (robosuite, contact_graspnet, LIBERO-PRO) — their `setup.py` import numpy at build time.
+- **LIBERO `future>=1.0`** — LIBERO pins `future==0.18.2`, whose `standard_library` does `import imp` (removed in Python 3.12), which breaks `pyglet → pyrender →` the GraspNet server. Upgrading `future` fixes it and LIBERO still imports.
+- **LIBERO non-interactive init** — LIBERO calls `input()` for a dataset path on first import; the build pre-seeds `~/.libero/config.yaml` so runtime is non-interactive.
+- **Trimmed submodule clone** — only the submodules the eval needs are inited (skips curobo/b1k/verl), saving significant build time and image size.
+
+Other tips:
+
+- **`invalid device function` / no GPU:** your part may need an HSA override. Set `HSA_OVERRIDE_GFX_VERSION` in `config.yaml` (e.g. `11.5.1` for gfx1151, `11.0.0` for gfx1103).
+- **Large local models are slow on an iGPU.** A 12B-class vision model is a good speed/quality balance; smaller models often write buggy code and score low — that's a model-quality outcome, not an infra problem.
+- **Trial timeout:** very slow local models can exceed CaP-X's per-trial wall-clock (`TRIAL_TIMEOUT_SECONDS` in `capx/envs/runner.py`). Lower `--max-tokens`, use fewer workers (less GPU contention), or raise the timeout.
+
+---
+
+## References
+
+- CaP-X: <https://github.com/capgym/cap-x> · [paper](https://arxiv.org/abs/2603.22435) · [project page](https://capgym.github.io/)
+- LIBERO-PRO: <https://github.com/uynitsuj/LIBERO-PRO>
+- Robosuite: <https://github.com/ARISE-Initiative/robosuite>

--- a/packages/robotics/capx/config.yaml
+++ b/packages/robotics/capx/config.yaml
@@ -1,58 +1,25 @@
 # Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# Ryzers package config for CaP-X (Robosuite / LIBERO-PRO eval path).
-#
-# Build:
-#   ryzers build capx                              # robosuite (default)
-#   ryzers build --name capx-libero capx           # see README to set CAPX_SIM=libero
-# Run:
-#   ryzers run                                     # runs the sign-of-life test
-#   ryzers run bash                                # interactive shell to launch evals
-#
-# GPU device flags (/dev/kfd, /dev/dri, video+render groups) and X11 are added
-# automatically by Ryzers — do not add them here.
-
-### ryzers build options
-
-# Keep this package on the ROCm/PyTorch combination validated below even if the
-# repository-wide default changes.
-init_image: "rocm/pytorch:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0"
 
 build_arguments:
 - "CAPX_SIM=robosuite"     # robosuite | libero  (mutually exclusive families)
-# Pin a specific CaP-X commit for reproducibility (defaults to an audited commit
-# in the Dockerfile). Uncomment to override:
-# - "CAPX_REF=53e9966d7a8e2fa7494676772bccc35280f5c0ed"
 
 ### ryzers run options
 
 environment_variables:
 # --- LLM provider (REQUIRED): an OpenAI-compatible endpoint ---------------
 # CaP-X queries an LLM over an OpenAI-compatible /chat/completions API. The
-# simplest path is OpenRouter, exactly like upstream. Get a key at
-# https://openrouter.ai/keys, then UNCOMMENT the line below and paste your key
-# (no angle brackets — the value is passed straight to the shell):
+# simplest path is OpenRouter, exactly like upstream.
 # - "OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxx"
-# For a LOCAL / on-prem OpenAI-compatible server instead (vLLM-ROCm, llama.cpp
-# llama-server, etc.), you don't need a key — see the README "Local / on-prem
-# LLM" section and point --server-url at your endpoint at run time.
 
 # --- SAM3 perception weights (OPTIONAL): gated on HuggingFace -------------
-# SAM3 (facebook/sam3) requires HF access approval + a token. Request access at
-# https://huggingface.co/facebook/sam3, create a token at
-# https://huggingface.co/settings/tokens, then UNCOMMENT and set:
+# SAM3 (facebook/sam3) requires HF access approval
 # - "HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxx"
-# If you leave this unset, use the ungated SAM2/OWLv2 perception path described
-# in the README (no token needed).
 
 # --- Rendering -----------------------------------------------------------
 - "MUJOCO_GL=egl"
 - "PYOPENGL_PLATFORM=egl"
-# Uncomment to force a GFX arch if you hit "invalid device function":
-#   Strix Halo (gfx1151):           "HSA_OVERRIDE_GFX_VERSION=11.5.1"
-#   Phoenix/Strix laptop (gfx1103): "HSA_OVERRIDE_GFX_VERSION=11.0.0"
-# - "HSA_OVERRIDE_GFX_VERSION=11.5.1"
 
 # Persist the HuggingFace weight cache (SAM3/GraspNet) across runs, and expose
 # eval outputs (videos, per-trial rewards) on the host.

--- a/packages/robotics/capx/config.yaml
+++ b/packages/robotics/capx/config.yaml
@@ -1,0 +1,62 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Ryzers package config for CaP-X (Robosuite / LIBERO-PRO eval path).
+#
+# Build:
+#   ryzers build capx                              # robosuite (default)
+#   ryzers build --name capx-libero capx           # see README to set CAPX_SIM=libero
+# Run:
+#   ryzers run                                     # runs the sign-of-life test
+#   ryzers run bash                                # interactive shell to launch evals
+#
+# GPU device flags (/dev/kfd, /dev/dri, video+render groups) and X11 are added
+# automatically by Ryzers — do not add them here.
+
+### ryzers build options
+
+build_arguments:
+- "CAPX_SIM=robosuite"     # robosuite | libero  (mutually exclusive families)
+# Pin a specific CaP-X commit for reproducibility (defaults to an audited commit
+# in the Dockerfile). Uncomment to override:
+# - "CAPX_REF=53e9966d7a8e2fa7494676772bccc35280f5c0ed"
+
+### ryzers run options
+
+environment_variables:
+# --- LLM provider (REQUIRED): an OpenAI-compatible endpoint ---------------
+# CaP-X queries an LLM over an OpenAI-compatible /chat/completions API. The
+# simplest path is OpenRouter, exactly like upstream. Get a key at
+# https://openrouter.ai/keys, then UNCOMMENT the line below and paste your key
+# (no angle brackets — the value is passed straight to the shell):
+# - "OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxx"
+# For a LOCAL / on-prem OpenAI-compatible server instead (vLLM-ROCm, llama.cpp
+# llama-server, etc.), you don't need a key — see the README "Local / on-prem
+# LLM" section and point --server-url at your endpoint at run time.
+
+# --- SAM3 perception weights (OPTIONAL): gated on HuggingFace -------------
+# SAM3 (facebook/sam3) requires HF access approval + a token. Request access at
+# https://huggingface.co/facebook/sam3, create a token at
+# https://huggingface.co/settings/tokens, then UNCOMMENT and set:
+# - "HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxx"
+# If you leave this unset, use the ungated SAM2/OWLv2 perception path described
+# in the README (no token needed).
+
+# --- Rendering -----------------------------------------------------------
+- "MUJOCO_GL=egl"
+# Uncomment to force a GFX arch if you hit "invalid device function":
+#   Strix Halo (gfx1151):           "HSA_OVERRIDE_GFX_VERSION=11.5.1"
+#   Phoenix/Strix laptop (gfx1103): "HSA_OVERRIDE_GFX_VERSION=11.0.0"
+# - "HSA_OVERRIDE_GFX_VERSION=11.5.1"
+
+# Persist the HuggingFace weight cache (SAM3/GraspNet) across runs, and expose
+# eval outputs (videos, per-trial rewards) on the host.
+volume_mappings:
+- "~/.cache/huggingface:/root/.cache/huggingface"
+- "$PWD/packages/robotics/capx/outputs:/ryzers/cap-x/outputs"
+
+# CaP-X serves perception + web UI on localhost ports. Ryzers runs with host
+# networking, so these are reachable directly. If you need to expose the
+# interactive web UI to another host, map it:
+# port_mappings:
+# - "8200:8200"   # CaP-X web UI

--- a/packages/robotics/capx/config.yaml
+++ b/packages/robotics/capx/config.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 #
 
+init_image: "rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0"
+
 build_arguments:
 - "CAPX_SIM=robosuite"     # robosuite | libero  (mutually exclusive families)
 
@@ -12,6 +14,11 @@ environment_variables:
 # CaP-X queries an LLM over an OpenAI-compatible /chat/completions API. The
 # simplest path is OpenRouter, exactly like upstream.
 # - "OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxx"
+
+# CAPX_LLM_* configures the optional stage 3 agentic evaluation.
+# - "CAPX_LLM_SERVER_URL=http://127.0.0.1:8110/chat/completions"
+# - "CAPX_LLM_MODEL=openrouter/google/gemini-3.1-pro-preview"
+# - "CAPX_LLM_TRIALS=1"
 
 # --- SAM3 perception weights (OPTIONAL): gated on HuggingFace -------------
 # SAM3 (facebook/sam3) requires HF access approval

--- a/packages/robotics/capx/config.yaml
+++ b/packages/robotics/capx/config.yaml
@@ -15,6 +15,10 @@
 
 ### ryzers build options
 
+# Keep this package on the ROCm/PyTorch combination validated below even if the
+# repository-wide default changes.
+init_image: "rocm/pytorch:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0"
+
 build_arguments:
 - "CAPX_SIM=robosuite"     # robosuite | libero  (mutually exclusive families)
 # Pin a specific CaP-X commit for reproducibility (defaults to an audited commit
@@ -44,6 +48,7 @@ environment_variables:
 
 # --- Rendering -----------------------------------------------------------
 - "MUJOCO_GL=egl"
+- "PYOPENGL_PLATFORM=egl"
 # Uncomment to force a GFX arch if you hit "invalid device function":
 #   Strix Halo (gfx1151):           "HSA_OVERRIDE_GFX_VERSION=11.5.1"
 #   Phoenix/Strix laptop (gfx1103): "HSA_OVERRIDE_GFX_VERSION=11.0.0"

--- a/packages/robotics/capx/config.yaml
+++ b/packages/robotics/capx/config.yaml
@@ -16,9 +16,10 @@ environment_variables:
 # - "OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxx"
 
 # CAPX_LLM_* configures the optional stage 3 agentic evaluation.
-# - "CAPX_LLM_SERVER_URL=http://127.0.0.1:8110/chat/completions"
-# - "CAPX_LLM_MODEL=openrouter/google/gemini-3.1-pro-preview"
+# - "CAPX_LLM_SERVER_URL=https://openrouter.ai/api/v1/chat/completions"
+# - "CAPX_LLM_MODEL=google/gemini-3.1-pro-preview"
 # - "CAPX_LLM_TRIALS=1"
+# - "CAPX_LLM_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxx"
 
 # --- SAM3 perception weights (OPTIONAL): gated on HuggingFace -------------
 # SAM3 (facebook/sam3) requires HF access approval

--- a/packages/robotics/capx/test.sh
+++ b/packages/robotics/capx/test.sh
@@ -130,6 +130,7 @@ else
             --config-path "${LLM_CONFIG}" \
             --model "${MODEL}" \
             --server-url "${CAPX_LLM_SERVER_URL}" \
+            --api-key "${CAPX_LLM_API_KEY:-}" \
             --total-trials "${TRIALS}" \
             --num-workers 1 \
             --max-tokens 4096 >"$LLM_LOG" 2>&1; then

--- a/packages/robotics/capx/test.sh
+++ b/packages/robotics/capx/test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Test for the CaP-X / ROCm image. Three stages:
+#   1. Sign-of-life: ROCm torch sees the GPU; the stack + simulator import;
+#      MuJoCo renders headless via EGL.
+#   2. Oracle eval (ALWAYS runs, no LLM/keys): runs a full CaP-Gym episode with
+#      the environment's ground-truth `oracle_code` through the real sim +
+#      PyRoKi IK pipeline and asserts task success (reward 1.0). This is the
+#      deterministic correctness check for the eval pipeline on ROCm.
+#   3. LLM eval (OPTIONAL): if CAPX_LLM_SERVER_URL is set, runs a short real
+#      agentic eval (LLM writes code -> sim executes -> reward) against any
+#      OpenAI-compatible endpoint. See the package README for how to point this
+#      at OpenRouter or a local/on-prem server (vLLM-ROCm, llama.cpp).
+set -e
+
+CAPX_SIM="${CAPX_SIM:-robosuite}"
+if [ "$CAPX_SIM" = "libero" ]; then
+    ORACLE_ENV="franka_libero_pick_place_code_env_privileged"
+    LLM_CONFIG="env_configs/libero/franka_libero_spatial_0.yaml"
+else
+    ORACLE_ENV="franka_robosuite_pick_place_code_env"
+    LLM_CONFIG="env_configs/cube_stack/franka_robosuite_cube_stack.yaml"
+fi
+
+cd /ryzers/cap-x
+
+echo "================ [1/3] CaP-X / ROCm sign-of-life ================"
+lsb_release -a 2>/dev/null || true
+python3 -c "
+import torch
+print(f'PyTorch : {torch.__version__}')
+print(f'ROCm/HIP: {torch.version.hip}')
+print(f'GPU ok  : {torch.cuda.is_available()}')
+if torch.cuda.is_available():
+    for i in range(torch.cuda.device_count()):
+        print(f'  device {i}: {torch.cuda.get_device_name(i)}')
+else:
+    raise SystemExit('No ROCm GPU visible - check /dev/kfd, /dev/dri and HSA_OVERRIDE_GFX_VERSION')
+"
+# jax is CPU-only by design (matches CaP-X's lock: jax 0.4.29, no GPU plugin).
+python3 -c "
+import capx, sam3, contact_graspnet_pytorch
+import jax; print('jax', jax.__version__, 'devices (CPU expected):', jax.devices())
+import pyroki, jaxls
+print('capx + pyroki import OK')
+"
+if [ "$CAPX_SIM" = "libero" ]; then
+    python3 -c "import libero, robosuite; print('LIBERO + robosuite import OK')"
+else
+    python3 -c "import robosuite; print('robosuite', robosuite.__version__, 'import OK')"
+fi
+MUJOCO_GL=egl python3 -c "
+import os; os.environ.setdefault('MUJOCO_GL','egl')
+import mujoco
+m = mujoco.MjModel.from_xml_string('<mujoco><worldbody><geom type=\"box\" size=\".1 .1 .1\"/></worldbody></mujoco>')
+d = mujoco.MjData(m); r = mujoco.Renderer(m, 64, 64); mujoco.mj_forward(m, d); r.update_scene(d)
+print('EGL render OK, frame shape', r.render().shape)
+" || echo 'WARN: MuJoCo EGL render failed - check libegl1/libgles2 and GPU access'
+
+echo "================ [2/3] Oracle eval (no LLM): ${ORACLE_ENV} ================"
+# The oracle path runs the full sim + control pipeline using ground-truth code.
+# It only needs the PyRoKi IK server (no LLM, no SAM3/GraspNet).
+python3 capx/serving/launch_pyroki_server.py \
+    --port 8116 --robot panda_description --target-link panda_hand \
+    > /tmp/pyroki.log 2>&1 &
+PYROKI_PID=$!
+echo "waiting for PyRoKi IK server..."
+for i in $(seq 1 60); do
+    curl -sf http://127.0.0.1:8116/ik -X POST -H "Content-Type: application/json" \
+        -d '{"target_pose_wxyz_xyz":[1,0,0,0,0.4,0,0.3]}' >/dev/null 2>&1 && { echo "PyRoKi ready (warmed JAX JIT) after ${i}s"; break; }
+    sleep 1
+done
+
+ORACLE_OUT=$(timeout 400 python3 tests/test_environments.py --env-name "${ORACLE_ENV}" 2>&1) || true
+echo "$ORACLE_OUT" | grep -aE "Time taken:|Reward:|Success" | tail -4
+kill $PYROKI_PID 2>/dev/null || true
+if echo "$ORACLE_OUT" | grep -aq "Success"; then
+    echo "ORACLE EVAL PASSED (reward 1.0)"
+else
+    echo "ORACLE EVAL FAILED"; echo "$ORACLE_OUT" | tail -20; exit 1
+fi
+
+echo "================ [3/3] LLM eval (optional) ================"
+if [ -z "${CAPX_LLM_SERVER_URL:-}" ]; then
+    echo "SKIPPED — set CAPX_LLM_SERVER_URL (and CAPX_LLM_MODEL) to run a real"
+    echo "agentic eval against an OpenAI-compatible endpoint. See README."
+else
+    MODEL="${CAPX_LLM_MODEL:-gemma4}"
+    TRIALS="${CAPX_LLM_TRIALS:-2}"
+    echo "Running ${TRIALS}-trial eval: model=${MODEL} server=${CAPX_LLM_SERVER_URL}"
+    echo "config=${LLM_CONFIG}"
+    timeout 1800 python3 capx/envs/launch.py \
+        --config-path "${LLM_CONFIG}" \
+        --model "${MODEL}" \
+        --server-url "${CAPX_LLM_SERVER_URL}" \
+        --total-trials "${TRIALS}" \
+        --num-workers 1 \
+        --max-tokens 4096 2>&1 | grep -aE "Trial [0-9]+ took|reward_|task_completed|Time taken to query" | tail -12
+    echo "LLM EVAL COMPLETE (see outputs/<model>/ for per-trial rewards + videos)"
+fi
+
+echo "================ CaP-X tests PASSED ================"

--- a/packages/robotics/capx/test.sh
+++ b/packages/robotics/capx/test.sh
@@ -13,7 +13,7 @@
 #      agentic eval (LLM writes code -> sim executes -> reward) against any
 #      OpenAI-compatible endpoint. See the package README for how to point this
 #      at OpenRouter or a local/on-prem server (vLLM-ROCm, llama.cpp).
-set -e
+set -euo pipefail
 
 CAPX_SIM="${CAPX_SIM:-robosuite}"
 if [ "$CAPX_SIM" = "libero" ]; then
@@ -33,6 +33,8 @@ import torch
 print(f'PyTorch : {torch.__version__}')
 print(f'ROCm/HIP: {torch.version.hip}')
 print(f'GPU ok  : {torch.cuda.is_available()}')
+if torch.version.hip is None:
+    raise SystemExit('This is not a ROCm/HIP PyTorch build')
 if torch.cuda.is_available():
     for i in range(torch.cuda.device_count()):
         print(f'  device {i}: {torch.cuda.get_device_name(i)}')
@@ -55,31 +57,63 @@ MUJOCO_GL=egl python3 -c "
 import os; os.environ.setdefault('MUJOCO_GL','egl')
 import mujoco
 m = mujoco.MjModel.from_xml_string('<mujoco><worldbody><geom type=\"box\" size=\".1 .1 .1\"/></worldbody></mujoco>')
-d = mujoco.MjData(m); r = mujoco.Renderer(m, 64, 64); mujoco.mj_forward(m, d); r.update_scene(d)
-print('EGL render OK, frame shape', r.render().shape)
-" || echo 'WARN: MuJoCo EGL render failed - check libegl1/libgles2 and GPU access'
+d = mujoco.MjData(m)
+r = mujoco.Renderer(m, 64, 64)
+try:
+    mujoco.mj_forward(m, d)
+    r.update_scene(d)
+    print('EGL render OK, frame shape', r.render().shape)
+finally:
+    r.close()
+"
 
 echo "================ [2/3] Oracle eval (no LLM): ${ORACLE_ENV} ================"
 # The oracle path runs the full sim + control pipeline using ground-truth code.
 # It only needs the PyRoKi IK server (no LLM, no SAM3/GraspNet).
+PYROKI_PID=""
+cleanup_pyroki() {
+    if [ -n "${PYROKI_PID:-}" ] && kill -0 "$PYROKI_PID" 2>/dev/null; then
+        kill "$PYROKI_PID" 2>/dev/null || true
+        wait "$PYROKI_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_pyroki EXIT
+
 python3 capx/serving/launch_pyroki_server.py \
     --port 8116 --robot panda_description --target-link panda_hand \
     > /tmp/pyroki.log 2>&1 &
 PYROKI_PID=$!
 echo "waiting for PyRoKi IK server..."
+PYROKI_READY=0
 for i in $(seq 1 60); do
-    curl -sf http://127.0.0.1:8116/ik -X POST -H "Content-Type: application/json" \
-        -d '{"target_pose_wxyz_xyz":[1,0,0,0,0.4,0,0.3]}' >/dev/null 2>&1 && { echo "PyRoKi ready (warmed JAX JIT) after ${i}s"; break; }
+    if curl -sf http://127.0.0.1:8116/ik -X POST -H "Content-Type: application/json" \
+        -d '{"target_pose_wxyz_xyz":[1,0,0,0,0.4,0,0.3]}' >/dev/null 2>&1; then
+        echo "PyRoKi ready (warmed JAX JIT) after ${i}s"
+        PYROKI_READY=1
+        break
+    fi
     sleep 1
 done
+if [ "$PYROKI_READY" -ne 1 ]; then
+    echo "PyRoKi failed to become ready"
+    cat /tmp/pyroki.log
+    exit 1
+fi
 
-ORACLE_OUT=$(timeout 400 python3 tests/test_environments.py --env-name "${ORACLE_ENV}" 2>&1) || true
-echo "$ORACLE_OUT" | grep -aE "Time taken:|Reward:|Success" | tail -4
-kill $PYROKI_PID 2>/dev/null || true
-if echo "$ORACLE_OUT" | grep -aq "Success"; then
+if ! ORACLE_OUT=$(timeout 400 python3 tests/test_environments.py --env-name "${ORACLE_ENV}" 2>&1); then
+    echo "ORACLE EVAL FAILED"
+    tail -20 <<<"$ORACLE_OUT"
+    exit 1
+fi
+grep -aE "Time taken:|Reward:|Success" <<<"$ORACLE_OUT" | tail -4 || true
+cleanup_pyroki
+trap - EXIT
+if grep -aq '^Success$' <<<"$ORACLE_OUT"; then
     echo "ORACLE EVAL PASSED (reward 1.0)"
 else
-    echo "ORACLE EVAL FAILED"; echo "$ORACLE_OUT" | tail -20; exit 1
+    echo "ORACLE EVAL FAILED"
+    tail -20 <<<"$ORACLE_OUT"
+    exit 1
 fi
 
 echo "================ [3/3] LLM eval (optional) ================"
@@ -91,13 +125,21 @@ else
     TRIALS="${CAPX_LLM_TRIALS:-2}"
     echo "Running ${TRIALS}-trial eval: model=${MODEL} server=${CAPX_LLM_SERVER_URL}"
     echo "config=${LLM_CONFIG}"
-    timeout 1800 python3 capx/envs/launch.py \
-        --config-path "${LLM_CONFIG}" \
-        --model "${MODEL}" \
-        --server-url "${CAPX_LLM_SERVER_URL}" \
-        --total-trials "${TRIALS}" \
-        --num-workers 1 \
-        --max-tokens 4096 2>&1 | grep -aE "Trial [0-9]+ took|reward_|task_completed|Time taken to query" | tail -12
+    LLM_LOG=$(mktemp)
+    if ! timeout 1800 python3 capx/envs/launch.py \
+            --config-path "${LLM_CONFIG}" \
+            --model "${MODEL}" \
+            --server-url "${CAPX_LLM_SERVER_URL}" \
+            --total-trials "${TRIALS}" \
+            --num-workers 1 \
+            --max-tokens 4096 >"$LLM_LOG" 2>&1; then
+        echo "LLM EVAL FAILED"
+        tail -40 "$LLM_LOG"
+        rm -f "$LLM_LOG"
+        exit 1
+    fi
+    grep -aE "Trial [0-9]+ took|reward_|task_completed|Time taken to query" "$LLM_LOG" | tail -12 || true
+    rm -f "$LLM_LOG"
     echo "LLM EVAL COMPLETE (see outputs/<model>/ for per-trial rewards + videos)"
 fi
 


### PR DESCRIPTION
- Pinned init_image to rocm7.14 in config.yaml for llamacpp
- ROCm 7.14 has no /opt/rocm and rocm/pytorch ships only runtime
  wheels, so enable_language(HIP) fails; hence, installed rocm[devel]
- Pointed HIPCXX/HIP_PATH/CMAKE_PREFIX_PATH at the devel tree
- Registered wheel lib dirs with ldconfig so that the binaries find libhipblas
- Changed clang to clang++, AMDGPU_TARGETS to GPU_TARGETS, and dropped LLAMA_CURL
